### PR TITLE
refactor: split monolith into engine, profile, and display modules

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1,11 +1,12 @@
--- HunterFlow M1.1: AssistedCombat queue with cast-tracked Hunter state
+-- HunterFlow: AssistedCombat rotation overlay with cast-tracked state
 -- Copyright (C) 2026 itsDNNS
 -- Licensed under GPL-3.0-or-later. See LICENSE.
--- Initial implementation scope: BM Hunter (Spec 253)
 
 ------------------------------------------------------------------------
--- Saved variables & defaults
+-- Global namespace & saved variables
 ------------------------------------------------------------------------
+
+HunterFlow = HunterFlow or {}
 
 HunterFlowDB = HunterFlowDB or {}
 
@@ -16,579 +17,96 @@ local DEFAULTS = {
     locked = false,
 }
 
-local function GetOpt(key)
+function HunterFlow.GetOpt(key)
     if HunterFlowDB[key] ~= nil then return HunterFlowDB[key] end
     return DEFAULTS[key]
 end
 
 ------------------------------------------------------------------------
--- Override rule engine
+-- Lifecycle
 ------------------------------------------------------------------------
 
--- Rule types: "BLACKLIST", "PIN", "PREFER"
--- Conditions: { type = "usable", spellID = N }
---             { type = "target_casting" }
---             { type = "target_count", op = ">=", value = N }
---             { type = "burst_mode" }
---             { type = "and", left = cond, right = cond }
+local Engine  -- resolved after all files load
+local Display
 
-local burstModeActive = false
-local combatStartTime = nil
-
-------------------------------------------------------------------------
--- Dark Ranger state machine (cast-event-based CD tracking)
-------------------------------------------------------------------------
-
-local DR = {
-    blackArrowReady = true,       -- BA off CD / Deathblow proc available
-    lastBlackArrowCast = 0,       -- timestamp of last BA cast
-    lastBWCast = 0,               -- timestamp of last BW cast
-    witheringFireUntil = 0,       -- BW cast time + 10s
-    wailingArrowAvailable = false, -- WA becomes available after BW
-    lastCastWasKC = false,        -- Nature's Ally: don't double KC
-}
-local BA_COOLDOWN = 10
-local BW_COOLDOWN_ESTIMATE = 29  -- base CD 30s, 1s buffer
-
-local function ResetDRState()
-    DR.blackArrowReady = true
-    DR.lastBlackArrowCast = 0
-    DR.lastBWCast = 0
-    DR.witheringFireUntil = 0
-    DR.wailingArrowAvailable = false
-    DR.lastCastWasKC = false
+local function GetActiveSpecID()
+    local specIndex = GetSpecialization()
+    if not specIndex then return nil end
+    return GetSpecializationInfo(specIndex)
 end
 
-local function UpdateDRState(spellID)
-    local now = GetTime()
+local function TryActivate()
+    Engine = HunterFlow.Engine
+    Display = HunterFlow.Display
 
-    if spellID == 466930 then -- Black Arrow
-        DR.blackArrowReady = false
-        DR.lastBlackArrowCast = now
-        DR.lastCastWasKC = false
-
-    elseif spellID == 19574 then -- Bestial Wrath
-        DR.blackArrowReady = true        -- guaranteed Deathblow
-        DR.lastBWCast = now              -- track BW cast time for CD estimate
-        DR.witheringFireUntil = now + 10 -- Withering Fire window
-        DR.wailingArrowAvailable = true  -- WA unlocks
-        DR.lastCastWasKC = false
-
-    elseif spellID == 392060 then -- Wailing Arrow
-        DR.blackArrowReady = true        -- guaranteed Deathblow
-        DR.wailingArrowAvailable = false
-        DR.lastCastWasKC = false
-
-    elseif spellID == 34026 then -- Kill Command
-        DR.lastCastWasKC = true
-        -- 10% Deathblow chance - can't detect, timer fallback handles it
-
-    else
-        DR.lastCastWasKC = false
-        -- Barbed Shot (217200) has 50% Deathblow - timer fallback
-    end
-
-    -- Timer fallback: if BA CD elapsed, assume ready
-    if not DR.blackArrowReady and DR.lastBlackArrowCast > 0 then
-        if (now - DR.lastBlackArrowCast) >= BA_COOLDOWN then
-            DR.blackArrowReady = true
-        end
-    end
-end
-
-local function IsInWitheringFire()
-    return GetTime() < DR.witheringFireUntil
-end
-
-local function WitheringFireRemaining()
-    local remaining = DR.witheringFireUntil - GetTime()
-    return remaining > 0 and remaining or 0
-end
-
-local function EvalCondition(cond)
-    if not cond then return true end
-
-    if cond.type == "usable" then
-        if C_Spell and C_Spell.IsSpellUsable then
-            local ok, result = pcall(C_Spell.IsSpellUsable, cond.spellID)
-            return ok and result == true
-        end
+    local specID = GetActiveSpecID()
+    if not specID then
+        Display:Disable()
         return false
+    end
 
-    elseif cond.type == "target_casting" then
-        if UnitExists("target") then
-            local casting = UnitCastingInfo("target")
-            local channeling = UnitChannelInfo("target")
-            return (casting ~= nil) or (channeling ~= nil)
-        end
+    if not Engine:ActivateProfile(specID) then
+        Display:Disable()
         return false
-
-    elseif cond.type == "target_count" then
-        local plates = C_NamePlate.GetNamePlates() or {}
-        local count = 0
-        for _, plate in ipairs(plates) do
-            local unit = plate.namePlateUnitToken
-            if unit and UnitExists(unit) and UnitCanAttack("player", unit) then
-                count = count + 1
-            end
-        end
-        if cond.op == ">=" then return count >= cond.value end
-        if cond.op == ">" then return count > cond.value end
-        return false
-
-    elseif cond.type == "burst_mode" then
-        return burstModeActive
-
-    elseif cond.type == "combat_opening" then
-        if not combatStartTime then return false end
-        return (GetTime() - combatStartTime) <= (cond.duration or 2)
-
-    elseif cond.type == "ba_ready" then
-        -- Timer fallback check before evaluating
-        if not DR.blackArrowReady and DR.lastBlackArrowCast > 0 then
-            if (GetTime() - DR.lastBlackArrowCast) >= BA_COOLDOWN then
-                DR.blackArrowReady = true
-            end
-        end
-        return DR.blackArrowReady
-
-    elseif cond.type == "in_withering_fire" then
-        return IsInWitheringFire()
-
-    elseif cond.type == "wf_ending" then
-        -- Withering Fire has less than N seconds remaining
-        local threshold = cond.seconds or 4
-        return IsInWitheringFire() and WitheringFireRemaining() <= threshold
-
-    elseif cond.type == "wa_available" then
-        return DR.wailingArrowAvailable
-
-    elseif cond.type == "last_cast_was_kc" then
-        return DR.lastCastWasKC
-
-    elseif cond.type == "bw_on_cd" then
-        if DR.lastBWCast == 0 then return false end
-        return (GetTime() - DR.lastBWCast) < BW_COOLDOWN_ESTIMATE
-
-    elseif cond.type == "not" then
-        return not EvalCondition(cond.inner)
-
-    elseif cond.type == "and" then
-        return EvalCondition(cond.left) and EvalCondition(cond.right)
-
-    elseif cond.type == "or" then
-        return EvalCondition(cond.left) or EvalCondition(cond.right)
     end
 
-    return false
-end
-
-local function IsSpellCastable(spellID)
-    if not spellID then return false end
-    -- Gate: spell must be both known AND usable
-    -- Probe showed Multi-Shot as known=false, usable=true - must reject that
-    local known = IsPlayerSpell(spellID)
-    if not known then return false end
-    if C_Spell and C_Spell.IsSpellUsable then
-        local ok, result = pcall(C_Spell.IsSpellUsable, spellID)
-        return ok and result == true
-    end
-    return false
-end
-
-------------------------------------------------------------------------
--- BM Hunter default profile (Spec 253)
-------------------------------------------------------------------------
-
-local BM_PROFILE = {
-    specID = 253,
-    rules = {
-        -- Filter utility spells from rotation queue
-        { type = "BLACKLIST", spellID = 883 },   -- Call Pet 1
-        { type = "BLACKLIST", spellID = 982 },   -- Revive Pet
-
-        -- Counter Shot: kept out of the primary queue by default
-        { type = "BLACKLIST", spellID = 147362 }, -- Counter Shot
-
-        -- Bestial Wrath: suppress from queue when recently cast (CD estimate)
-        {
-            type = "BLACKLIST_CONDITIONAL",
-            spellID = 19574, -- Bestial Wrath
-            condition = { type = "bw_on_cd" },
-        },
-
-        -- During Withering Fire: Black Arrow is highest DPS priority
-        -- (fires 2 extra arrows at nearby targets)
-        {
-            type = "PIN",
-            spellID = 466930, -- Black Arrow
-            condition = {
-                type = "and",
-                left  = { type = "ba_ready" },
-                right = { type = "in_withering_fire" },
-            },
-        },
-
-        -- Wailing Arrow: cast near end of Withering Fire (<4s remaining)
-        -- Grants another Deathblow for one more BA in the window
-        {
-            type = "PREFER",
-            spellID = 392060, -- Wailing Arrow
-            condition = {
-                type = "and",
-                left  = { type = "wa_available" },
-                right = { type = "wf_ending", seconds = 4 },
-            },
-        },
-
-        -- Outside Withering Fire: prefer Black Arrow when ready (on CD)
-        {
-            type = "PREFER",
-            spellID = 466930, -- Black Arrow
-            condition = {
-                type = "and",
-                left  = { type = "ba_ready" },
-                right = { type = "not", inner = { type = "in_withering_fire" } },
-            },
-        },
-
-        -- Nature's Ally: never recommend Kill Command twice in a row
-        -- If last cast was KC, defer it (let AC suggest something else)
-        {
-            type = "BLACKLIST_CONDITIONAL",
-            spellID = 34026, -- Kill Command
-            condition = { type = "last_cast_was_kc" },
-        },
-    },
-}
-
-local activeProfile = BM_PROFILE
-
-------------------------------------------------------------------------
--- Queue computation
-------------------------------------------------------------------------
-
-local blacklistedSpells = {}
-
-local function RebuildBlacklist()
-    wipe(blacklistedSpells)
-    for _, rule in ipairs(activeProfile.rules) do
-        if rule.type == "BLACKLIST" then
-            blacklistedSpells[rule.spellID] = true
-        end
-    end
-end
-
-local function ComputeQueue()
-    local queue = {}
-
-    -- 1. Get base recommendation from Blizzard
     if not C_AssistedCombat or not C_AssistedCombat.IsAvailable() then
-        return queue
+        Display:Disable()
+        return false
     end
 
-    local baseSpell = C_AssistedCombat.GetNextCastSpell()
-
-    -- 2. Build conditional blacklist for this frame
-    local condBlacklist = {}
-    for _, rule in ipairs(activeProfile.rules) do
-        if rule.type == "BLACKLIST_CONDITIONAL" and EvalCondition(rule.condition) then
-            condBlacklist[rule.spellID] = true
-        end
-    end
-
-    local function IsBlocked(spellID)
-        return blacklistedSpells[spellID] or condBlacklist[spellID]
-    end
-
-    -- 3. Evaluate PIN rules (highest priority, first match wins)
-    local pinnedSpell = nil
-    for _, rule in ipairs(activeProfile.rules) do
-        if rule.type == "PIN" and EvalCondition(rule.condition) then
-            if IsSpellCastable(rule.spellID) and not IsBlocked(rule.spellID) then
-                pinnedSpell = rule.spellID
-                break
-            end
-        end
-    end
-
-    -- 4. Evaluate PREFER rules (only if no PIN fired)
-    local preferredSpell = nil
-    if not pinnedSpell then
-        for _, rule in ipairs(activeProfile.rules) do
-            if rule.type == "PREFER" and EvalCondition(rule.condition) then
-                if IsSpellCastable(rule.spellID) and not IsBlocked(rule.spellID) then
-                    preferredSpell = rule.spellID
-                    break
-                end
-            end
-        end
-    end
-
-    -- 5. Determine position 1
-    -- If base spell is conditionally blacklisted, skip it
-    if baseSpell and IsBlocked(baseSpell) then baseSpell = nil end
-    local pos1 = pinnedSpell or preferredSpell or baseSpell
-    if pos1 and not IsBlocked(pos1) then
-        queue[#queue + 1] = pos1
-    end
-
-    -- 5. Fill positions 2+ from GetRotationSpells()
-    local rotSpells = C_AssistedCombat.GetRotationSpells()
-    if rotSpells then
-        local seen = {}
-        if pos1 then seen[pos1] = true end
-
-        for _, entry in ipairs(rotSpells) do
-            if #queue >= GetOpt("iconCount") then break end
-
-            local spellID = entry
-            -- GetRotationSpells might return tables or raw IDs
-            if type(entry) == "table" then
-                spellID = entry.spellID or entry[1]
-            end
-
-            if spellID
-                and not seen[spellID]
-                and not IsBlocked(spellID)
-                and IsSpellCastable(spellID)
-            then
-                queue[#queue + 1] = spellID
-                seen[spellID] = true
-            end
-        end
-    end
-
-    return queue
+    Display:Enable()
+    return true
 end
 
 ------------------------------------------------------------------------
--- Display
-------------------------------------------------------------------------
-
-local container = CreateFrame("Frame", "HunterFlowFrame", UIParent,
-    "BackdropTemplate")
-container:SetSize(200, 50)
-container:SetPoint("CENTER", UIParent, "CENTER", 0, -50)
-container:SetMovable(true)
-container:EnableMouse(true)
-container:SetClampedToScreen(true)
-container:RegisterForDrag("LeftButton")
-container:SetScript("OnDragStart", function(self)
-    if not GetOpt("locked") then self:StartMoving() end
-end)
-container:SetScript("OnDragStop", function(self)
-    self:StopMovingOrSizing()
-end)
-
-local icons = {}
-
-local function GetKeybindForSpell(spellID)
-    -- Scan action bars for the spell and return its keybind
-    for slot = 1, 120 do
-        local actionType, id = GetActionInfo(slot)
-        if actionType == "spell" and id == spellID then
-            local key = GetBindingKey("ACTIONBUTTON" .. ((slot - 1) % 12 + 1))
-            if not key then
-                local bar = math.ceil(slot / 12)
-                local btn = (slot - 1) % 12 + 1
-                if bar == 1 then
-                    key = GetBindingKey("ACTIONBUTTON" .. btn)
-                elseif bar <= 6 then
-                    key = GetBindingKey("MULTIACTIONBAR" .. (bar - 1) .. "BUTTON" .. btn)
-                end
-            end
-            if key then return key end
-        end
-    end
-    return nil
-end
-
-local function CreateIcon(index)
-    local size = GetOpt("iconSize")
-    local spacing = GetOpt("iconSpacing")
-
-    local frame = CreateFrame("Frame", "HunterFlowIcon" .. index,
-        container, "BackdropTemplate")
-    frame:SetSize(size, size)
-    frame:SetPoint("LEFT", container, "LEFT",
-        (index - 1) * (size + spacing), 0)
-
-    frame.texture = frame:CreateTexture(nil, "ARTWORK")
-    frame.texture:SetAllPoints()
-    frame.texture:SetTexCoord(0.07, 0.93, 0.07, 0.93)
-
-    frame.keybind = frame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmallGray")
-    frame.keybind:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -2, -2)
-    frame.keybind:SetJustifyH("RIGHT")
-
-    frame.cooldown = CreateFrame("Cooldown", "HunterFlowCD" .. index,
-        frame, "CooldownFrameTemplate")
-    frame.cooldown:SetAllPoints()
-    frame.cooldown:SetDrawSwipe(true)
-    frame.cooldown:SetDrawEdge(true)
-    frame.cooldown:SetSwipeColor(0, 0, 0, 0.6)
-
-    frame.border = frame:CreateTexture(nil, "OVERLAY")
-    frame.border:SetAllPoints()
-    frame.border:SetAtlas("UI-HUD-ActionBar-IconFrame")
-
-    -- Dim icons after position 1
-    if index > 1 then
-        frame:SetAlpha(0.7)
-    end
-
-    frame:Hide()
-    return frame
-end
-
-local function EnsureIcons()
-    local count = GetOpt("iconCount")
-    while #icons < count do
-        icons[#icons + 1] = CreateIcon(#icons + 1)
-    end
-end
-
-local function UpdateContainerSize()
-    local count = GetOpt("iconCount")
-    local size = GetOpt("iconSize")
-    local spacing = GetOpt("iconSpacing")
-    container:SetSize(count * size + (count - 1) * spacing, size)
-end
-
-local function UpdateDisplay(queue)
-    EnsureIcons()
-    local count = GetOpt("iconCount")
-
-    for i = 1, count do
-        local icon = icons[i]
-        local spellID = queue[i]
-
-        if spellID then
-            local texture = C_Spell.GetSpellTexture(spellID)
-            if texture then
-                icon.texture:SetTexture(texture)
-                local key = GetKeybindForSpell(spellID)
-                icon.keybind:SetText(key or "")
-
-                -- Cooldown sweep: pass secret cooldown object directly to
-                -- Blizzard's renderer without reading/comparing the values
-                if icon.cooldown and C_Spell.GetSpellCooldown then
-                    local ok, cdInfo = pcall(C_Spell.GetSpellCooldown, spellID)
-                    if ok and cdInfo then
-                        local setOk = pcall(icon.cooldown.SetCooldownFromDurationObject,
-                            icon.cooldown, cdInfo)
-                        if not setOk then
-                            icon.cooldown:Clear()
-                        end
-                    else
-                        icon.cooldown:Clear()
-                    end
-                end
-
-                icon:Show()
-            else
-                icon:Hide()
-            end
-        else
-            icon:Hide()
-            if icon.cooldown then icon.cooldown:Clear() end
-        end
-    end
-end
-
-------------------------------------------------------------------------
--- Update throttle
-------------------------------------------------------------------------
-
-local UPDATE_INTERVAL = 0.1
-local timeSinceUpdate = 0
-
-local function OnUpdate(self, elapsed)
-    timeSinceUpdate = timeSinceUpdate + elapsed
-    if timeSinceUpdate < UPDATE_INTERVAL then return end
-    timeSinceUpdate = 0
-
-    local queue = ComputeQueue()
-    UpdateDisplay(queue)
-end
-
-------------------------------------------------------------------------
--- Events & lifecycle
+-- Events
 ------------------------------------------------------------------------
 
 local eventFrame = CreateFrame("Frame")
-
 eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
 eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 eventFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
 
-local function Enable()
-    RebuildBlacklist()
-    UpdateContainerSize()
-    EnsureIcons()
-    container:EnableMouse(not GetOpt("locked"))
-    container:Show()
-    container:SetScript("OnUpdate", OnUpdate)
-end
-
-local function Disable()
-    container:SetScript("OnUpdate", nil)
-    container:Hide()
-end
-
-local BM_HUNTER_SPEC_ID = 253
-
-local function IsBMHunter()
-    local specIndex = GetSpecialization()
-    if not specIndex then return false end
-    local specID = GetSpecializationInfo(specIndex)
-    return specID == BM_HUNTER_SPEC_ID
-end
-
-local function CheckSpecAndToggle()
-    if not IsBMHunter() then
-        Disable()
-        return false
-    end
-    if not C_AssistedCombat or not C_AssistedCombat.IsAvailable() then
-        Disable()
-        return false
-    end
-    return true
-end
-
 eventFrame:SetScript("OnEvent", function(self, event, ...)
+    Engine = HunterFlow.Engine
+    Display = HunterFlow.Display
+
     if event == "PLAYER_ENTERING_WORLD" then
-        ResetDRState()
-        if CheckSpecAndToggle() then
-            Enable()
-            print("|cff00ff00[HunterFlow]|r loaded. Initial profile: BM Hunter.")
+        if TryActivate() then
+            local profile = Engine.activeProfile
+            local name = profile and profile.id or "unknown"
+            print("|cff00ff00[HunterFlow]|r loaded. Profile: " .. name)
             print("|cffaaaaaa  /hf lock|unlock|burst|help|r")
-        elseif not IsBMHunter() then
-            print("|cffaaaaaa[HunterFlow]|r Not BM Hunter. Addon inactive.")
         else
-            print("|cffff0000[HunterFlow]|r Assisted Combat not available.")
+            local specID = GetActiveSpecID()
+            if not HunterFlow.Profiles[specID or 0] then
+                print("|cffaaaaaa[HunterFlow]|r No profile for current spec. Addon inactive.")
+            else
+                print("|cffff0000[HunterFlow]|r Assisted Combat not available.")
+            end
         end
+
     elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
         local unit, _, spellID = ...
         if unit == "player" and spellID then
-            UpdateDRState(spellID)
+            Engine:OnSpellCast(spellID)
         end
+
     elseif event == "PLAYER_REGEN_DISABLED" then
-        combatStartTime = GetTime()
-        if IsBMHunter() and not container:IsShown() then Enable() end
-    elseif event == "PLAYER_REGEN_ENABLED" then
-        combatStartTime = nil
-        DR.lastCastWasKC = false
-    elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
-        ResetDRState()
-        if CheckSpecAndToggle() then
-            RebuildBlacklist()
-            Enable()
+        Engine.combatStartTime = GetTime()
+        if Engine.activeProfile and not Display.container:IsShown() then
+            Display:Enable()
         end
+
+    elseif event == "PLAYER_REGEN_ENABLED" then
+        Engine.combatStartTime = nil
+        Engine:OnCombatEnd()
+
+    elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
+        TryActivate()
     end
 end)
 
@@ -599,58 +117,60 @@ end)
 SLASH_HUNTERFLOW1 = "/hf"
 SLASH_HUNTERFLOW2 = "/hunterflow"
 SlashCmdList["HUNTERFLOW"] = function(msg)
+    Engine = HunterFlow.Engine
+    Display = HunterFlow.Display
     msg = msg:lower():trim()
 
     if msg == "lock" then
         HunterFlowDB.locked = true
-        container:EnableMouse(false)
+        Display:SetClickThrough(true)
         print("|cff00ff00[HF]|r Frame locked (click-through).")
 
     elseif msg == "unlock" then
         HunterFlowDB.locked = false
-        container:EnableMouse(true)
+        Display:SetClickThrough(false)
         print("|cff00ff00[HF]|r Frame unlocked. Drag to reposition.")
 
     elseif msg == "burst" then
-        burstModeActive = not burstModeActive
-        if burstModeActive then
+        Engine.burstModeActive = not Engine.burstModeActive
+        if Engine.burstModeActive then
             print("|cff00ff00[HF]|r Burst mode ON")
         else
             print("|cff00ff00[HF]|r Burst mode OFF")
         end
 
     elseif msg == "hide" then
-        Disable()
+        Display:Disable()
         print("|cff00ff00[HF]|r Hidden. /hf show to restore.")
 
     elseif msg == "show" then
-        Enable()
+        Display:Enable()
 
     elseif msg == "debug" then
-        local queue = ComputeQueue()
+        local queue = Engine:ComputeQueue(HunterFlow.GetOpt("iconCount"))
         print("|cff00ff00[HF] Queue:|r")
         for i, id in ipairs(queue) do
             local name = C_Spell.GetSpellName(id) or "?"
-            local usable = IsSpellCastable(id) and "usable" or "not usable"
-            print("  " .. i .. ": " .. name .. " (" .. id .. ") [" .. usable .. "]")
+            local castable = Engine:IsSpellCastable(id) and "usable" or "not usable"
+            print("  " .. i .. ": " .. name .. " (" .. id .. ") [" .. castable .. "]")
         end
-        print("|cff00ff00[HF] BM State:|r")
-        print("  BA ready: " .. tostring(DR.blackArrowReady))
-        print("  Withering Fire: " .. (IsInWitheringFire()
-            and string.format("%.1fs remaining", WitheringFireRemaining())
-            or "inactive"))
-        print("  Wailing Arrow: " .. (DR.wailingArrowAvailable and "available" or "not available"))
-        print("  Last cast was KC: " .. tostring(DR.lastCastWasKC))
-        print("  Burst mode: " .. tostring(burstModeActive))
+        local profile = Engine.activeProfile
+        if profile and profile.GetDebugLines then
+            print("|cff00ff00[HF] Profile State:|r")
+            for _, line in ipairs(profile:GetDebugLines()) do
+                print(line)
+            end
+        end
+        print("  Burst mode: " .. tostring(Engine.burstModeActive))
 
     elseif msg == "help" then
         print("|cff00ff00[HunterFlow]|r Commands:")
-        print("  /hf lock    - Lock frame position")
+        print("  /hf lock    - Lock frame (click-through)")
         print("  /hf unlock  - Unlock frame for dragging")
         print("  /hf burst   - Toggle burst mode")
         print("  /hf hide    - Hide the display")
         print("  /hf show    - Show the display")
-        print("  /hf debug   - Print current queue")
+        print("  /hf debug   - Print queue and profile state")
 
     else
         print("|cff00ff00[HunterFlow]|r Use /hf help for commands.")

--- a/Display.lua
+++ b/Display.lua
@@ -1,0 +1,154 @@
+-- HunterFlow Display: presentation layer for the queue overlay
+
+local Engine = HunterFlow.Engine
+
+HunterFlow.Display = {}
+local Display = HunterFlow.Display
+
+------------------------------------------------------------------------
+-- Container frame
+------------------------------------------------------------------------
+
+local container = CreateFrame("Frame", "HunterFlowFrame", UIParent,
+    "BackdropTemplate")
+container:SetSize(200, 50)
+container:SetPoint("CENTER", UIParent, "CENTER", 0, -50)
+container:SetMovable(true)
+container:EnableMouse(true)
+container:SetClampedToScreen(true)
+container:RegisterForDrag("LeftButton")
+container:SetScript("OnDragStart", function(self)
+    if not HunterFlow.GetOpt("locked") then self:StartMoving() end
+end)
+container:SetScript("OnDragStop", function(self)
+    self:StopMovingOrSizing()
+end)
+
+Display.container = container
+
+------------------------------------------------------------------------
+-- Icons
+------------------------------------------------------------------------
+
+local icons = {}
+
+local function GetKeybindForSpell(spellID)
+    for slot = 1, 120 do
+        local actionType, id = GetActionInfo(slot)
+        if actionType == "spell" and id == spellID then
+            local key = GetBindingKey("ACTIONBUTTON" .. ((slot - 1) % 12 + 1))
+            if not key then
+                local bar = math.ceil(slot / 12)
+                local btn = (slot - 1) % 12 + 1
+                if bar == 1 then
+                    key = GetBindingKey("ACTIONBUTTON" .. btn)
+                elseif bar <= 6 then
+                    key = GetBindingKey("MULTIACTIONBAR" .. (bar - 1) .. "BUTTON" .. btn)
+                end
+            end
+            if key then return key end
+        end
+    end
+    return nil
+end
+
+local function CreateIcon(index)
+    local size = HunterFlow.GetOpt("iconSize")
+    local spacing = HunterFlow.GetOpt("iconSpacing")
+
+    local frame = CreateFrame("Frame", "HunterFlowIcon" .. index,
+        container, "BackdropTemplate")
+    frame:SetSize(size, size)
+    frame:SetPoint("LEFT", container, "LEFT",
+        (index - 1) * (size + spacing), 0)
+
+    frame.texture = frame:CreateTexture(nil, "ARTWORK")
+    frame.texture:SetAllPoints()
+    frame.texture:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+
+    frame.keybind = frame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmallGray")
+    frame.keybind:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -2, -2)
+    frame.keybind:SetJustifyH("RIGHT")
+
+    -- TODO: GCD sweep needs SecureDelegate research
+
+    frame.border = frame:CreateTexture(nil, "OVERLAY")
+    frame.border:SetAllPoints()
+    frame.border:SetAtlas("UI-HUD-ActionBar-IconFrame")
+
+    if index > 1 then
+        frame:SetAlpha(0.7)
+    end
+
+    frame:Hide()
+    return frame
+end
+
+local function EnsureIcons()
+    local count = HunterFlow.GetOpt("iconCount")
+    while #icons < count do
+        icons[#icons + 1] = CreateIcon(#icons + 1)
+    end
+end
+
+function Display:UpdateContainerSize()
+    local count = HunterFlow.GetOpt("iconCount")
+    local size = HunterFlow.GetOpt("iconSize")
+    local spacing = HunterFlow.GetOpt("iconSpacing")
+    container:SetSize(count * size + (count - 1) * spacing, size)
+end
+
+function Display:UpdateQueue(queue)
+    EnsureIcons()
+    local count = HunterFlow.GetOpt("iconCount")
+
+    for i = 1, count do
+        local icon = icons[i]
+        local spellID = queue[i]
+
+        if spellID then
+            local texture = C_Spell.GetSpellTexture(spellID)
+            if texture then
+                icon.texture:SetTexture(texture)
+                local key = GetKeybindForSpell(spellID)
+                icon.keybind:SetText(key or "")
+                icon:Show()
+            else
+                icon:Hide()
+            end
+        else
+            icon:Hide()
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Update throttle
+------------------------------------------------------------------------
+
+local UPDATE_INTERVAL = 0.1
+local timeSinceUpdate = 0
+
+function Display:Enable()
+    self:UpdateContainerSize()
+    EnsureIcons()
+    container:EnableMouse(not HunterFlow.GetOpt("locked"))
+    container:Show()
+    container:SetScript("OnUpdate", function(_, elapsed)
+        timeSinceUpdate = timeSinceUpdate + elapsed
+        if timeSinceUpdate < UPDATE_INTERVAL then return end
+        timeSinceUpdate = 0
+
+        local queue = Engine:ComputeQueue(HunterFlow.GetOpt("iconCount"))
+        Display:UpdateQueue(queue)
+    end)
+end
+
+function Display:Disable()
+    container:SetScript("OnUpdate", nil)
+    container:Hide()
+end
+
+function Display:SetClickThrough(locked)
+    container:EnableMouse(not locked)
+end

--- a/Engine.lua
+++ b/Engine.lua
@@ -1,0 +1,219 @@
+-- HunterFlow Engine: generic queue computation and condition evaluation
+-- Profile-agnostic - delegates spec-specific conditions to the active profile
+
+HunterFlow = HunterFlow or {}
+HunterFlow.Engine = {}
+
+local Engine = HunterFlow.Engine
+
+Engine.burstModeActive = false
+Engine.combatStartTime = nil
+Engine.activeProfile = nil
+
+------------------------------------------------------------------------
+-- Condition evaluator (generic conditions only)
+------------------------------------------------------------------------
+
+function Engine:EvalCondition(cond)
+    if not cond then return true end
+
+    if cond.type == "usable" then
+        if C_Spell and C_Spell.IsSpellUsable then
+            local ok, result = pcall(C_Spell.IsSpellUsable, cond.spellID)
+            return ok and result == true
+        end
+        return false
+
+    elseif cond.type == "target_casting" then
+        if UnitExists("target") then
+            local casting = UnitCastingInfo("target")
+            local channeling = UnitChannelInfo("target")
+            return (casting ~= nil) or (channeling ~= nil)
+        end
+        return false
+
+    elseif cond.type == "target_count" then
+        local plates = C_NamePlate.GetNamePlates() or {}
+        local count = 0
+        for _, plate in ipairs(plates) do
+            local unit = plate.namePlateUnitToken
+            if unit and UnitExists(unit) and UnitCanAttack("player", unit) then
+                count = count + 1
+            end
+        end
+        if cond.op == ">=" then return count >= cond.value end
+        if cond.op == ">" then return count > cond.value end
+        return false
+
+    elseif cond.type == "burst_mode" then
+        return self.burstModeActive
+
+    elseif cond.type == "combat_opening" then
+        if not self.combatStartTime then return false end
+        return (GetTime() - self.combatStartTime) <= (cond.duration or 2)
+
+    elseif cond.type == "not" then
+        return not self:EvalCondition(cond.inner)
+
+    elseif cond.type == "and" then
+        return self:EvalCondition(cond.left) and self:EvalCondition(cond.right)
+
+    elseif cond.type == "or" then
+        return self:EvalCondition(cond.left) or self:EvalCondition(cond.right)
+    end
+
+    -- Delegate to active profile for profile-specific conditions
+    if self.activeProfile and self.activeProfile.EvalCondition then
+        local result = self.activeProfile:EvalCondition(cond)
+        if result ~= nil then return result end
+    end
+
+    return false
+end
+
+------------------------------------------------------------------------
+-- Spell legality gate
+------------------------------------------------------------------------
+
+function Engine:IsSpellCastable(spellID)
+    if not spellID then return false end
+    local known = IsPlayerSpell(spellID)
+    if not known then return false end
+    if C_Spell and C_Spell.IsSpellUsable then
+        local ok, result = pcall(C_Spell.IsSpellUsable, spellID)
+        return ok and result == true
+    end
+    return false
+end
+
+------------------------------------------------------------------------
+-- Queue computation
+------------------------------------------------------------------------
+
+local blacklistedSpells = {}
+
+function Engine:RebuildBlacklist()
+    wipe(blacklistedSpells)
+    if not self.activeProfile then return end
+    for _, rule in ipairs(self.activeProfile.rules) do
+        if rule.type == "BLACKLIST" then
+            blacklistedSpells[rule.spellID] = true
+        end
+    end
+end
+
+function Engine:ComputeQueue(iconCount)
+    local queue = {}
+    local profile = self.activeProfile
+    if not profile then return queue end
+
+    if not C_AssistedCombat or not C_AssistedCombat.IsAvailable() then
+        return queue
+    end
+
+    local baseSpell = C_AssistedCombat.GetNextCastSpell()
+
+    -- Build conditional blacklist for this frame
+    local condBlacklist = {}
+    for _, rule in ipairs(profile.rules) do
+        if rule.type == "BLACKLIST_CONDITIONAL" and self:EvalCondition(rule.condition) then
+            condBlacklist[rule.spellID] = true
+        end
+    end
+
+    local function IsBlocked(spellID)
+        return blacklistedSpells[spellID] or condBlacklist[spellID]
+    end
+
+    -- PIN rules (highest priority, first match wins)
+    local pinnedSpell = nil
+    for _, rule in ipairs(profile.rules) do
+        if rule.type == "PIN" and self:EvalCondition(rule.condition) then
+            if self:IsSpellCastable(rule.spellID) and not IsBlocked(rule.spellID) then
+                pinnedSpell = rule.spellID
+                break
+            end
+        end
+    end
+
+    -- PREFER rules (only if no PIN fired)
+    local preferredSpell = nil
+    if not pinnedSpell then
+        for _, rule in ipairs(profile.rules) do
+            if rule.type == "PREFER" and self:EvalCondition(rule.condition) then
+                if self:IsSpellCastable(rule.spellID) and not IsBlocked(rule.spellID) then
+                    preferredSpell = rule.spellID
+                    break
+                end
+            end
+        end
+    end
+
+    -- Position 1
+    if baseSpell and IsBlocked(baseSpell) then baseSpell = nil end
+    local pos1 = pinnedSpell or preferredSpell or baseSpell
+    if pos1 and not IsBlocked(pos1) then
+        queue[#queue + 1] = pos1
+    end
+
+    -- Positions 2+ from GetRotationSpells()
+    local rotSpells = C_AssistedCombat.GetRotationSpells()
+    if rotSpells then
+        local seen = {}
+        if pos1 then seen[pos1] = true end
+
+        for _, entry in ipairs(rotSpells) do
+            if #queue >= iconCount then break end
+
+            local spellID = entry
+            if type(entry) == "table" then
+                spellID = entry.spellID or entry[1]
+            end
+
+            if spellID
+                and not seen[spellID]
+                and not IsBlocked(spellID)
+                and self:IsSpellCastable(spellID)
+            then
+                queue[#queue + 1] = spellID
+                seen[spellID] = true
+            end
+        end
+    end
+
+    return queue
+end
+
+------------------------------------------------------------------------
+-- Profile management
+------------------------------------------------------------------------
+
+HunterFlow.Profiles = {}
+
+function Engine:RegisterProfile(profile)
+    HunterFlow.Profiles[profile.specID] = profile
+end
+
+function Engine:ActivateProfile(specID)
+    local profile = HunterFlow.Profiles[specID]
+    if profile then
+        self.activeProfile = profile
+        if profile.ResetState then profile:ResetState() end
+        self:RebuildBlacklist()
+        return true
+    end
+    self.activeProfile = nil
+    return false
+end
+
+function Engine:OnSpellCast(spellID)
+    if self.activeProfile and self.activeProfile.OnSpellCast then
+        self.activeProfile:OnSpellCast(spellID)
+    end
+end
+
+function Engine:OnCombatEnd()
+    if self.activeProfile and self.activeProfile.OnCombatEnd then
+        self.activeProfile:OnCombatEnd()
+    end
+end

--- a/HunterFlow.toc
+++ b/HunterFlow.toc
@@ -1,8 +1,11 @@
 ## Interface: 120000
 ## Title: HunterFlow
-## Notes: Hunter rotation overlay for WoW Midnight. Initial profile: BM Hunter.
+## Notes: Hunter rotation overlay for WoW Midnight. Initial profile: BM / Dark Ranger.
 ## Author: itsDNNS
-## Version: 0.1.1-alpha
+## Version: 0.2.0-alpha
 ## SavedVariables: HunterFlowDB
 
+Engine.lua
+Profiles/BM_DarkRanger.lua
+Display.lua
 Core.lua

--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -1,0 +1,192 @@
+-- HunterFlow Profile: Beast Mastery / Dark Ranger (Spec 253)
+-- Cast-event state machine for Black Arrow, Bestial Wrath, Wailing Arrow
+
+local Engine = HunterFlow.Engine
+
+local BA_COOLDOWN = 10
+local BW_COOLDOWN_ESTIMATE = 29
+
+------------------------------------------------------------------------
+-- Profile definition
+------------------------------------------------------------------------
+
+local Profile = {
+    id = "Hunter.BM.DarkRanger",
+    specID = 253,
+
+    state = {
+        blackArrowReady = true,
+        lastBlackArrowCast = 0,
+        lastBWCast = 0,
+        witheringFireUntil = 0,
+        wailingArrowAvailable = false,
+        lastCastWasKC = false,
+    },
+
+    rules = {
+        -- Filter utility spells
+        { type = "BLACKLIST", spellID = 883 },    -- Call Pet 1
+        { type = "BLACKLIST", spellID = 982 },    -- Revive Pet
+        { type = "BLACKLIST", spellID = 147362 }, -- Counter Shot (user preference)
+
+        -- Bestial Wrath: suppress when recently cast
+        {
+            type = "BLACKLIST_CONDITIONAL",
+            spellID = 19574,
+            condition = { type = "bw_on_cd" },
+        },
+
+        -- During Withering Fire: Black Arrow is highest DPS priority
+        {
+            type = "PIN",
+            spellID = 466930, -- Black Arrow
+            condition = {
+                type = "and",
+                left  = { type = "ba_ready" },
+                right = { type = "in_withering_fire" },
+            },
+        },
+
+        -- Wailing Arrow near end of Withering Fire
+        {
+            type = "PREFER",
+            spellID = 392060, -- Wailing Arrow
+            condition = {
+                type = "and",
+                left  = { type = "wa_available" },
+                right = { type = "wf_ending", seconds = 4 },
+            },
+        },
+
+        -- Outside Withering Fire: prefer Black Arrow when ready
+        {
+            type = "PREFER",
+            spellID = 466930, -- Black Arrow
+            condition = {
+                type = "and",
+                left  = { type = "ba_ready" },
+                right = { type = "not", inner = { type = "in_withering_fire" } },
+            },
+        },
+
+        -- Nature's Ally: never Kill Command twice in a row
+        {
+            type = "BLACKLIST_CONDITIONAL",
+            spellID = 34026,
+            condition = { type = "last_cast_was_kc" },
+        },
+    },
+}
+
+------------------------------------------------------------------------
+-- State machine
+------------------------------------------------------------------------
+
+function Profile:ResetState()
+    self.state.blackArrowReady = true
+    self.state.lastBlackArrowCast = 0
+    self.state.lastBWCast = 0
+    self.state.witheringFireUntil = 0
+    self.state.wailingArrowAvailable = false
+    self.state.lastCastWasKC = false
+end
+
+function Profile:OnSpellCast(spellID)
+    local now = GetTime()
+    local s = self.state
+
+    if spellID == 466930 then -- Black Arrow
+        s.blackArrowReady = false
+        s.lastBlackArrowCast = now
+        s.lastCastWasKC = false
+
+    elseif spellID == 19574 then -- Bestial Wrath
+        s.blackArrowReady = true
+        s.lastBWCast = now
+        s.witheringFireUntil = now + 10
+        s.wailingArrowAvailable = true
+        s.lastCastWasKC = false
+
+    elseif spellID == 392060 then -- Wailing Arrow
+        s.blackArrowReady = true
+        s.wailingArrowAvailable = false
+        s.lastCastWasKC = false
+
+    elseif spellID == 34026 then -- Kill Command
+        s.lastCastWasKC = true
+
+    else
+        s.lastCastWasKC = false
+    end
+
+    -- Timer fallback: if BA CD elapsed, assume ready
+    if not s.blackArrowReady and s.lastBlackArrowCast > 0 then
+        if (now - s.lastBlackArrowCast) >= BA_COOLDOWN then
+            s.blackArrowReady = true
+        end
+    end
+end
+
+function Profile:OnCombatEnd()
+    self.state.lastCastWasKC = false
+end
+
+------------------------------------------------------------------------
+-- Profile-specific condition evaluation
+------------------------------------------------------------------------
+
+function Profile:EvalCondition(cond)
+    local s = self.state
+
+    if cond.type == "ba_ready" then
+        if not s.blackArrowReady and s.lastBlackArrowCast > 0 then
+            if (GetTime() - s.lastBlackArrowCast) >= BA_COOLDOWN then
+                s.blackArrowReady = true
+            end
+        end
+        return s.blackArrowReady
+
+    elseif cond.type == "in_withering_fire" then
+        return GetTime() < s.witheringFireUntil
+
+    elseif cond.type == "wf_ending" then
+        local threshold = cond.seconds or 4
+        local remaining = s.witheringFireUntil - GetTime()
+        return remaining > 0 and remaining <= threshold
+
+    elseif cond.type == "wa_available" then
+        return s.wailingArrowAvailable
+
+    elseif cond.type == "last_cast_was_kc" then
+        return s.lastCastWasKC
+
+    elseif cond.type == "bw_on_cd" then
+        if s.lastBWCast == 0 then return false end
+        return (GetTime() - s.lastBWCast) < BW_COOLDOWN_ESTIMATE
+    end
+
+    return nil -- not handled by this profile
+end
+
+------------------------------------------------------------------------
+-- Debug output
+------------------------------------------------------------------------
+
+function Profile:GetDebugLines()
+    local s = self.state
+    local wfRemaining = s.witheringFireUntil - GetTime()
+    return {
+        "  BA ready: " .. tostring(s.blackArrowReady),
+        "  Withering Fire: " .. (wfRemaining > 0
+            and string.format("%.1fs remaining", wfRemaining)
+            or "inactive"),
+        "  Wailing Arrow: " .. (s.wailingArrowAvailable and "available" or "not available"),
+        "  Last cast was KC: " .. tostring(s.lastCastWasKC),
+    }
+end
+
+------------------------------------------------------------------------
+-- Register
+------------------------------------------------------------------------
+
+Engine:RegisterProfile(Profile)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The addon does not try to recreate old full-state rotation engines. Instead, it 
 - multiple spec profiles
 - explicit rules about what Blizzard's API still allows and what it does not
 
+The overall project goals are documented in [Project Goals](docs/PROJECT_GOALS.md).
+
 ## Status
 
 `HunterFlow` is currently an `alpha`.
@@ -59,6 +61,7 @@ It does **not** claim to be a full replacement for legacy full-state rotation si
 
 The framework direction is documented here:
 
+- [Project Goals](docs/PROJECT_GOALS.md)
 - [API Constraints](docs/API_CONSTRAINTS.md)
 - [Framework Model](docs/FRAMEWORK.md)
 - [Profile Contract](docs/PROFILE_CONTRACT.md)

--- a/docs/PROJECT_GOALS.md
+++ b/docs/PROJECT_GOALS.md
@@ -1,0 +1,96 @@
+# Project Goals
+
+`HunterFlow` needs explicit product goals so framework work, profile work, and UI work do not drift into contradictory directions.
+
+## Primary Goal
+
+Build a hunter-focused recommendation framework for Retail `Midnight` that is:
+
+- lightweight
+- performant on the live client
+- honest about API limits
+- still functionally useful enough that players can rely on it as a real rotational aid
+
+In short:
+
+`HunterFlow` should aim for the highest practical gameplay value per unit of client overhead.
+
+## Product Principles
+
+### 1. Performance is a feature
+
+The addon should feel cheap to run.
+
+That means:
+
+- prefer event-driven state over constant recomputation
+- prefer short, explainable rule evaluation over broad simulation
+- avoid expensive per-frame work unless it is directly tied to visible output
+- avoid unnecessary allocations, scans, or duplicate API calls in combat
+- keep the UI small and responsive
+
+### 2. Lightweight does not mean useless
+
+The goal is not a tiny toy addon.
+
+The goal is to stay lightweight **while still delivering the full practical functionality that is defensible under the `Midnight` API**.
+
+That means `HunterFlow` should still try to provide:
+
+- a reliable recommendation queue
+- spec-aware profile behavior where signals are legal and validated
+- configurable, understandable overrides
+- useful debug visibility
+- graceful fallback behavior when a signal is unavailable
+
+### 3. Full functionality has a boundary
+
+`HunterFlow` should pursue broad functionality inside the legal API surface, not outside it.
+
+So "full functionality" does **not** mean:
+
+- recreating a legacy full-state simulation engine
+- pretending hidden resources, cooldowns, or aura state are known
+- piling on features that require constant heavy polling or opaque inference
+
+### 4. Explainability beats cleverness
+
+Every rule should be understandable.
+
+If a feature needs too much invisible state, too much CPU, or too much guesswork to justify itself, it should be reduced, deferred, or rejected.
+
+### 5. Degrade safely
+
+When a signal cannot be trusted:
+
+- the profile should fall back cleanly
+- the engine should prefer Blizzard `Assisted Combat`
+- the addon should become simpler rather than wrong
+
+## Engineering Implications
+
+These goals imply a few concrete defaults:
+
+- engine work should bias toward shared, reusable, low-overhead logic
+- profiles should own narrowly scoped, validated rule/state logic
+- UI should stay compact and cheap instead of becoming a heavyweight configuration surface
+- new features should justify both their gameplay value and their runtime cost
+- probe work and signal validation should happen before adding expensive or speculative behavior
+
+## Non-Goals
+
+`HunterFlow` is not trying to become:
+
+- a kitchen-sink UI addon
+- a hidden-state combat simulator
+- a feature pile that grows faster than its validation model
+- a framework that treats performance as something to optimize later
+
+## Review Standard
+
+A change is aligned only if it can answer both questions well:
+
+1. Does this improve practical player value?
+2. Does this preserve the lightweight, low-overhead character of the addon?
+
+If the answer to either is weak, the change should be challenged before it lands.


### PR DESCRIPTION
## Summary

Split the alpha monolith (`Core.lua`, 642 lines) into four focused modules:

- `Engine.lua` - generic queue computation, condition evaluation, profile management
- `Profiles/BM_DarkRanger.lua` - BM-specific state machine, rules, conditions
- `Display.lua` - container, icons, keybind detection, update loop
- `Core.lua` - lifecycle glue, events, slash commands, saved variables

## Design

The profile contract allows future specs to register as self-contained modules without modifying the engine. Profile-specific conditions (`ba_ready`, `in_withering_fire`, etc.) are delegated from the engine to the active profile via `EvalCondition()`.

```text
TOC load order: Engine -> Profile -> Display -> Core
```

## Verification

- Behavior remains aligned with the previous alpha scope
- Verified in-game after `/reload`
- All commands (`/hf debug`, `/hf lock`, etc.) work unchanged

Closes #1
Closes #2
