### PR TITLE
docs: add profile authoring kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The framework direction is documented here:
 - [API Constraints](docs/API_CONSTRAINTS.md)
 - [Framework Model](docs/FRAMEWORK.md)
 - [Profile Contract](docs/PROFILE_CONTRACT.md)
+- [Profile Authoring Guide](docs/PROFILE_AUTHORING.md)
 
 These docs are meant to capture the hard-won findings from the `Midnight` API changes so future class/spec integrations do not repeat the same mistakes.
 They describe the target architecture, not a claim that the current alpha is already fully modularized.

--- a/docs/FRAMEWORK.md
+++ b/docs/FRAMEWORK.md
@@ -1,12 +1,12 @@
 # Framework Model
 
-`HunterFlow` should evolve into a framework with three layers:
+`HunterFlow` is now structured around three layers:
 
 1. `Engine`
 2. `Profile`
 3. `Presentation`
 
-The current addon still ships as a single-file alpha, but this is the target architecture rather than a description of the current internal file layout.
+The current addon already uses this split in code, but the framework is still early and intentionally narrow in runtime scope.
 
 ## 1. Engine
 
@@ -60,7 +60,7 @@ Presentation owns:
 - icon count
 - positioning
 - click-through behavior
-- cooldown/GCD sweep rendering
+- future cooldown/GCD sweep rendering when a lightweight legal implementation exists
 - text overlays / keybind overlays
 
 Presentation must not own combat logic.
@@ -142,10 +142,10 @@ The engine should never fail hard when a profile-specific heuristic cannot run.
 
 ## Current Reality
 
-Today, `HunterFlow` is still earlier than this target architecture:
+Today, `HunterFlow` is still earlier than the eventual broader framework goal:
 
-- one live `Core.lua`
-- one active BM profile path
-- state tracked in engine-level locals rather than profile objects
+- one shared engine
+- one shipped BM profile path
+- one compact display implementation
 
-That is acceptable for the alpha. The purpose of this document is to define where the code should move next.
+That is acceptable for the alpha. The purpose of this document is to define how the code should keep expanding without losing its lightweight character.

--- a/docs/PROFILE_AUTHORING.md
+++ b/docs/PROFILE_AUTHORING.md
@@ -1,0 +1,179 @@
+# Profile Authoring Guide
+
+This guide turns the current `HunterFlow` framework into a repeatable authoring workflow for new hunter profiles and hero-path variants.
+
+Use this together with:
+
+- [Project Goals](PROJECT_GOALS.md)
+- [API Constraints](API_CONSTRAINTS.md)
+- [Framework Model](FRAMEWORK.md)
+- [Profile Contract](PROFILE_CONTRACT.md)
+
+The goal is not to encode every desirable idea from a guide.
+The goal is to ship a profile that is:
+
+- legal under `Midnight`
+- lightweight on the client
+- explainable in review
+- honest about fallbacks
+
+## Quick Start
+
+1. Copy [`HunterProfileTemplate.lua`](templates/HunterProfileTemplate.lua).
+2. Rename it for the target profile, for example `Profiles/MM_Sentinel.lua`.
+3. Write down the guide or priority source you are translating.
+4. Classify each desired mechanic as:
+   - `direct`
+   - `heuristic`
+   - `impossible`
+   - `unknown`
+5. Keep only the mechanics that survive the API and runtime-cost checks.
+6. Implement state and rules for those mechanics.
+7. Add the profile file to `HunterFlow.toc` only when it is ready to register.
+8. Test with `/hf debug` before claiming the profile is usable.
+
+## Rule Classification
+
+Every desired mechanic must be classified before it becomes code.
+
+### `direct`
+
+Use this when the rule depends on data that is intentionally available.
+
+Examples:
+
+- Blizzard `C_AssistedCombat` recommendations
+- `IsPlayerSpell(spellID)`
+- `UNIT_SPELLCAST_SUCCEEDED` for `player`
+
+### `heuristic`
+
+Use this when the rule depends on a legal inference from observable events.
+
+Examples:
+
+- "Bestial Wrath was cast 8 seconds ago, so the Withering Fire window is probably still active."
+- "Black Arrow was cast 11 seconds ago, so it is probably ready again."
+
+Every heuristic must document:
+
+- what event starts it
+- what event clears it
+- what timer or fallback bounds it
+- what happens if it becomes uncertain
+
+### `impossible`
+
+Use this when the mechanic depends on state that `HunterFlow` should not fake.
+
+Examples:
+
+- exact hidden cooldown remaining
+- exact `Focus`
+- hidden buff stack counts
+
+`Impossible` mechanics are not "later features".
+They are rejected until Blizzard exposes a legal signal.
+
+### `unknown`
+
+Use this when the signal might be usable, but has not been proven yet.
+
+Examples:
+
+- target counting on a spec that has not been validated in live AoE yet
+- a charge API that has not been tested on the relevant spell
+
+`Unknown` mechanics must become explicit probe work, not speculative code.
+
+## Runtime-Cost Filter
+
+Before writing a rule, answer these:
+
+1. Is the signal event-driven or does it require repeated polling?
+2. Does the rule add meaningful gameplay value or only theoretical fidelity?
+3. Can the rule degrade safely if the signal disappears?
+4. Is the same result already good enough through Blizzard `Assisted Combat`?
+5. Would this rule still be worth it if the addon must stay lightweight in combat?
+
+If the answer is weak, do not implement the rule yet.
+
+## Authoring Worksheet
+
+Fill this out before coding a new profile:
+
+| Desired mechanic | Source | Class | Runtime cost | Fallback | Keep? |
+| --- | --- | --- | --- | --- | --- |
+| Example: burst window | player cast event | heuristic | low | timer expires, fall back to AC | yes |
+| Example: exact proc stacks | hidden buff | impossible | n/a | none | no |
+
+## Worked Example: BM / Dark Ranger
+
+Guide-style intention:
+
+1. Use `Black Arrow` aggressively during `Withering Fire`.
+2. Spend `Wailing Arrow` near the end of `Withering Fire`.
+3. Avoid repeating `Kill Command` back-to-back.
+
+Translation:
+
+| Mechanic | Class | Why |
+| --- | --- | --- |
+| `Bestial Wrath` opens a 10s burst window | `heuristic` | player cast event plus bounded timer |
+| `Black Arrow` becomes ready again after `Bestial Wrath` / `Wailing Arrow` | `heuristic` | reset source is observable through player casts |
+| `Wailing Arrow` available after `Bestial Wrath` | `heuristic` | unlocked by observable cast, cleared by observable cast |
+| `Kill Command` anti-repeat weaving | `heuristic` | last player cast is observable |
+| exact Deathblow proc state | `impossible` or bounded fallback | proc source is not directly trustworthy, so only timer-based fallback is acceptable |
+
+Resulting rules:
+
+```text
+PIN Black Arrow WHEN ba_ready AND in_withering_fire
+PREFER Wailing Arrow WHEN wa_available AND wf_ending_lt_4
+BLACKLIST_CONDITIONAL Kill Command WHEN last_cast_was_kc
+```
+
+Why this is acceptable:
+
+- every active rule is backed by observable casts or a bounded local timer
+- nothing claims exact hidden resource or buff knowledge
+- when the heuristic is uncertain, Blizzard AC remains the baseline
+
+## Fallback Rules
+
+Every profile must state what happens when supporting signals fail.
+
+Examples:
+
+- If target casting is unavailable, do not surface interrupt guidance.
+- If target counting is unavailable, do not enable AoE preference logic.
+- If a cast-tracked timer becomes uncertain, fall back to Blizzard AC instead of forcing a speculative recommendation.
+
+## File Layout
+
+Current pattern for a real profile file:
+
+```text
+HunterFlow/
+  Engine.lua
+  Display.lua
+  Core.lua
+  Profiles/
+    BM_DarkRanger.lua
+```
+
+Authoring template:
+
+- [`HunterProfileTemplate.lua`](templates/HunterProfileTemplate.lua)
+
+Only add a new profile to `HunterFlow.toc` when the module is ready to register and be loaded by the addon.
+
+## Review Standard
+
+A new profile or hero-path rule is only ready if a reviewer can answer:
+
+1. Which signal makes this legal?
+2. Why is this lightweight enough to keep?
+3. What is the fallback when the signal is missing or uncertain?
+
+If those answers are not crisp, the profile is not ready yet.

--- a/docs/PROFILE_CONTRACT.md
+++ b/docs/PROFILE_CONTRACT.md
@@ -44,12 +44,14 @@ If hero/talent context cannot be proven safely, the profile must:
 
 ## State Hooks
 
-Profiles should eventually expose hooks like:
+Profiles should expose hooks like:
 
 ```lua
 profile:ResetState()
-profile:OnPlayerSpellCast(spellID, now)
-profile:IsRuleConditionTrue(condition, now)
+profile:OnSpellCast(spellID)
+profile:OnCombatEnd()
+profile:EvalCondition(condition)
+profile:GetDebugLines()
 ```
 
 This keeps spec-specific logic out of the generic queue engine.
@@ -81,7 +83,8 @@ Before adding a new class/spec profile:
 3. List all spells that must be cast-tracked.
 4. List every reset/proc source you can actually observe.
 5. Define fallback behavior for missing signals.
-6. Test the profile with `/debug` output before claiming correctness.
+6. Ask whether each rule is worth its runtime cost.
+7. Test the profile with `/hf debug` output before claiming correctness.
 
 ## BM / Dark Ranger Example
 
@@ -106,15 +109,22 @@ Rule examples:
 - `PREFER Wailing Arrow` near end of `Withering Fire`
 - conditionally suppress repeated `Kill Command`
 
-## Current Alpha Gap
+## Current State
 
-The current alpha implementation does **not** fully satisfy this contract yet:
+The current addon now has:
 
-- the BM profile is still hard-coded in `Core.lua`
-- state still lives in engine-level locals
-- hero-path-specific heuristics are documented as tested behavior, not as a separately gated profile module
+- a generic `Engine.lua`
+- a presentation layer in `Display.lua`
+- a real BM profile module in `Profiles/BM_DarkRanger.lua`
 
-That gap is intentional technical debt, not hidden architecture. This document defines the contract future extractions should satisfy.
+That means this contract is no longer hypothetical.
+It describes the actual direction new profile modules should follow.
+
+What is still intentionally narrow:
+
+- only one shipped hunter profile exists today
+- hero-path specificity is still encoded in that one BM profile module
+- future specs still need their own validated signal surface before implementation
 
 ## Public Rule Language
 

--- a/docs/templates/HunterProfileTemplate.lua
+++ b/docs/templates/HunterProfileTemplate.lua
@@ -1,0 +1,74 @@
+-- HunterFlow Profile Template
+-- Copy this file when starting a new profile module.
+-- Do not add the file to HunterFlow.toc until the profile is ready to load.
+
+local Engine = HunterFlow.Engine
+
+local Profile = {
+    id = "Hunter.MM.ExampleHero",
+    class = "HUNTER",
+    specID = 254,
+    hero = "ExampleHero",
+
+    -- Keep state small, explicit, and tied to observable signals.
+    state = {
+        burstWindowUntil = 0,
+        trackedSpellAvailable = false,
+        lastTrackedCast = 0,
+    },
+
+    rules = {
+        -- Example:
+        -- {
+        --     type = "PREFER",
+        --     spellID = 0,
+        --     condition = { type = "tracked_spell_ready" },
+        -- },
+    },
+}
+
+function Profile:ResetState()
+    self.state.burstWindowUntil = 0
+    self.state.trackedSpellAvailable = false
+    self.state.lastTrackedCast = 0
+end
+
+function Profile:OnSpellCast(spellID)
+    local now = GetTime()
+    local s = self.state
+
+    -- Replace with cast-driven transitions only.
+    if spellID == 0 then
+        s.trackedSpellAvailable = true
+        s.lastTrackedCast = now
+    else
+        -- Keep the default branch explicit.
+    end
+end
+
+function Profile:OnCombatEnd()
+    -- Reset only the state that must not survive combat.
+end
+
+function Profile:EvalCondition(cond)
+    local s = self.state
+
+    if cond.type == "tracked_spell_ready" then
+        return s.trackedSpellAvailable
+
+    elseif cond.type == "in_burst_window" then
+        return GetTime() < s.burstWindowUntil
+    end
+
+    return nil
+end
+
+function Profile:GetDebugLines()
+    local s = self.state
+    return {
+        "  Tracked spell ready: " .. tostring(s.trackedSpellAvailable),
+        "  Burst window until: " .. string.format("%.1f", s.burstWindowUntil),
+    }
+end
+
+Engine:RegisterProfile(Profile)


### PR DESCRIPTION
## Summary

Add the first real authoring kit for future HunterFlow profiles and hero-path variants.

Included here:
- `docs/PROFILE_AUTHORING.md` with a repeatable guide-to-rule workflow
- `docs/templates/HunterProfileTemplate.lua` as a scaffold that matches the current engine/profile shape
- updated framework and profile-contract docs to reflect the merged engine/profile split
- README link to the new authoring guide

## Verification

- template Lua file passes `luac -p`
- docs updated to match the current split architecture rather than the pre-split alpha state

Closes #3
