### PR TITLE
feat: signal probe harness and spell_charges condition

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -163,6 +163,10 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
         end
         print("  Burst mode: " .. tostring(Engine.burstModeActive))
 
+    elseif msg:sub(1, 5) == "probe" then
+        local probeArgs = msg:sub(7) or ""
+        HunterFlow.SignalProbe:HandleCommand(probeArgs)
+
     elseif msg == "help" then
         print("|cff00ff00[HunterFlow]|r Commands:")
         print("  /hf lock    - Lock frame (click-through)")
@@ -171,6 +175,7 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
         print("  /hf hide    - Hide the display")
         print("  /hf show    - Show the display")
         print("  /hf debug   - Print queue and profile state")
+        print("  /hf probe   - Signal validation probes (probe help for details)")
 
     else
         print("|cff00ff00[HunterFlow]|r Use /hf help for commands.")

--- a/Engine.lua
+++ b/Engine.lua
@@ -10,6 +10,10 @@ Engine.burstModeActive = false
 Engine.combatStartTime = nil
 Engine.activeProfile = nil
 
+local function IsSecret(val)
+    return issecretvalue and issecretvalue(val) or false
+end
+
 ------------------------------------------------------------------------
 -- Condition evaluator (generic conditions only)
 ------------------------------------------------------------------------
@@ -26,14 +30,19 @@ function Engine:EvalCondition(cond)
 
     elseif cond.type == "target_casting" then
         if UnitExists("target") then
-            local casting = UnitCastingInfo("target")
-            local channeling = UnitChannelInfo("target")
-            return (casting ~= nil) or (channeling ~= nil)
+            local ok1, casting = pcall(UnitCastingInfo, "target")
+            local ok2, channeling = pcall(UnitChannelInfo, "target")
+            if not ok1 and not ok2 then return false end
+            if IsSecret(casting) or IsSecret(channeling) then return false end
+            return (ok1 and casting ~= nil) or (ok2 and channeling ~= nil)
         end
         return false
 
     elseif cond.type == "target_count" then
-        local plates = C_NamePlate.GetNamePlates() or {}
+        if not C_NamePlate or not C_NamePlate.GetNamePlates then return false end
+        local ok, plates = pcall(C_NamePlate.GetNamePlates)
+        if not ok or not plates then return false end
+        if IsSecret(plates) then return false end
         local count = 0
         for _, plate in ipairs(plates) do
             local unit = plate.namePlateUnitToken
@@ -43,6 +52,21 @@ function Engine:EvalCondition(cond)
         end
         if cond.op == ">=" then return count >= cond.value end
         if cond.op == ">" then return count > cond.value end
+        return false
+
+    elseif cond.type == "spell_charges" then
+        if C_Spell and C_Spell.GetSpellCharges then
+            local ok, info = pcall(C_Spell.GetSpellCharges, cond.spellID)
+            if ok and info then
+                local charges = info.currentCharges
+                if IsSecret(charges) then return false end
+                if cond.op == ">=" then return charges >= cond.value end
+                if cond.op == ">"  then return charges >  cond.value end
+                if cond.op == "==" then return charges == cond.value end
+                if cond.op == "<"  then return charges <  cond.value end
+                if cond.op == "<=" then return charges <= cond.value end
+            end
+        end
         return false
 
     elseif cond.type == "burst_mode" then

--- a/HunterFlow.toc
+++ b/HunterFlow.toc
@@ -8,4 +8,5 @@
 Engine.lua
 Profiles/BM_DarkRanger.lua
 Display.lua
+SignalProbe.lua
 Core.lua

--- a/SignalProbe.lua
+++ b/SignalProbe.lua
@@ -1,0 +1,229 @@
+-- SignalProbe: in-game validation harness for shared hunter signals
+-- Run /hf probe <signal> to test API surfaces before profiles depend on them.
+-- Results feed into docs/SIGNAL_VALIDATION.md classification.
+
+HunterFlow = HunterFlow or {}
+HunterFlow.SignalProbe = {}
+
+local Probe = HunterFlow.SignalProbe
+
+local BARBED_SHOT_ID = 217200  -- BM charge-based spell for default testing
+
+------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------
+
+local function IsSecret(val)
+    return issecretvalue and issecretvalue(val) or false
+end
+
+local function SecretLabel(val)
+    if not issecretvalue then return "n/a (no issecretvalue)" end
+    if issecretvalue(val) then return "SECRET" end
+    return "not secret"
+end
+
+local function PrintHeader(name)
+    print("|cff00ff00[HF Probe]|r Testing: |cffffcc00" .. name .. "|r")
+end
+
+local function PrintResult(key, value)
+    print("  " .. key .. ": " .. tostring(value))
+end
+
+local function PrintClassification(label)
+    print("  => |cffffcc00Classification hint: " .. label .. "|r")
+end
+
+------------------------------------------------------------------------
+-- Probe: target casting
+------------------------------------------------------------------------
+
+function Probe:TargetCasting()
+    PrintHeader("target_casting (UnitCastingInfo / UnitChannelInfo)")
+
+    if not UnitExists("target") then
+        PrintResult("status", "no target selected")
+        PrintClassification("select a target and retry")
+        return
+    end
+
+    PrintResult("target", UnitName("target") or "?")
+
+    -- UnitCastingInfo
+    local ok1, casting = pcall(UnitCastingInfo, "target")
+    PrintResult("pcall UnitCastingInfo", ok1 and "ok" or "ERROR: " .. tostring(casting))
+    if ok1 then
+        PrintResult("casting name", tostring(casting))
+        PrintResult("casting secret", SecretLabel(casting))
+    end
+
+    -- UnitChannelInfo
+    local ok2, channeling = pcall(UnitChannelInfo, "target")
+    PrintResult("pcall UnitChannelInfo", ok2 and "ok" or "ERROR: " .. tostring(channeling))
+    if ok2 then
+        PrintResult("channeling name", tostring(channeling))
+        PrintResult("channeling secret", SecretLabel(channeling))
+    end
+
+    -- Classification hint
+    if not ok1 and not ok2 then
+        PrintClassification("IMPOSSIBLE - both APIs error")
+    elseif (ok1 and IsSecret(casting)) or (ok2 and IsSecret(channeling)) then
+        PrintClassification("SECRET - returns secret values")
+    elseif ok1 or ok2 then
+        PrintClassification("likely DIRECT - test while target is casting to confirm value changes")
+    end
+end
+
+------------------------------------------------------------------------
+-- Probe: nameplate count
+------------------------------------------------------------------------
+
+function Probe:NameplateCount()
+    PrintHeader("target_count (C_NamePlate.GetNamePlates)")
+
+    if not C_NamePlate or not C_NamePlate.GetNamePlates then
+        PrintResult("status", "C_NamePlate.GetNamePlates not available")
+        PrintClassification("IMPOSSIBLE - API missing")
+        return
+    end
+
+    local ok, plates = pcall(C_NamePlate.GetNamePlates)
+    PrintResult("pcall GetNamePlates", ok and "ok" or "ERROR: " .. tostring(plates))
+    if not ok then
+        PrintClassification("IMPOSSIBLE - API errors")
+        return
+    end
+
+    PrintResult("table secret", SecretLabel(plates))
+    if IsSecret(plates) then
+        PrintClassification("SECRET - table itself is secret")
+        return
+    end
+
+    local total = #plates
+    PrintResult("total nameplates", total)
+
+    local hostile = 0
+    local anyEntrySecret = false
+    for i, plate in ipairs(plates) do
+        local unit = plate.namePlateUnitToken
+        PrintResult("  plate " .. i .. " token", tostring(unit))
+        PrintResult("  plate " .. i .. " token secret", SecretLabel(unit))
+        if IsSecret(unit) then
+            anyEntrySecret = true
+        elseif unit and UnitExists(unit) then
+            local name = UnitName(unit) or "?"
+            local canAttack = UnitCanAttack("player", unit)
+            PrintResult("  plate " .. i .. " name", name)
+            PrintResult("  plate " .. i .. " canAttack", tostring(canAttack))
+            PrintResult("  plate " .. i .. " canAttack secret", SecretLabel(canAttack))
+            if IsSecret(canAttack) then
+                anyEntrySecret = true
+            elseif canAttack then
+                hostile = hostile + 1
+            end
+        end
+    end
+    PrintResult("hostile count", hostile)
+
+    -- Classification hint
+    if total == 0 then
+        PrintClassification("INCONCLUSIVE - no nameplates visible. Pull 2+ mobs and retry.")
+    elseif anyEntrySecret then
+        PrintClassification("PARTIAL - table readable but some entry fields are secret")
+    elseif hostile > 0 then
+        PrintClassification("likely DIRECT - verify count matches visible hostile mobs")
+    else
+        PrintClassification("PARTIAL - nameplates returned but no hostile units found")
+    end
+end
+
+------------------------------------------------------------------------
+-- Probe: spell charges
+------------------------------------------------------------------------
+
+function Probe:SpellCharges(spellID)
+    spellID = spellID or BARBED_SHOT_ID
+    local spellName = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(spellID) or "?"
+    PrintHeader("spell_charges (C_Spell.GetSpellCharges) - " .. spellName .. " (" .. spellID .. ")")
+
+    if not C_Spell or not C_Spell.GetSpellCharges then
+        PrintResult("status", "C_Spell.GetSpellCharges not available")
+        PrintClassification("IMPOSSIBLE - API missing")
+        return
+    end
+
+    local ok, info = pcall(C_Spell.GetSpellCharges, spellID)
+    PrintResult("pcall GetSpellCharges", ok and "ok" or "ERROR: " .. tostring(info))
+    if not ok then
+        PrintClassification("IMPOSSIBLE - API errors for this spell")
+        return
+    end
+
+    if not info then
+        PrintResult("status", "nil (spell may not be charge-based or not known)")
+        PrintClassification("check that you have this spell talented")
+        return
+    end
+
+    PrintResult("currentCharges", tostring(info.currentCharges))
+    PrintResult("currentCharges secret", SecretLabel(info.currentCharges))
+    PrintResult("maxCharges", tostring(info.maxCharges))
+    PrintResult("maxCharges secret", SecretLabel(info.maxCharges))
+    PrintResult("cooldownStartTime", tostring(info.cooldownStartTime))
+    PrintResult("cooldownStartTime secret", SecretLabel(info.cooldownStartTime))
+    PrintResult("cooldownDuration", tostring(info.cooldownDuration))
+    PrintResult("cooldownDuration secret", SecretLabel(info.cooldownDuration))
+
+    -- Classification hint
+    if IsSecret(info.currentCharges) then
+        PrintClassification("SECRET - charge count is secret")
+    elseif IsSecret(info.cooldownStartTime) then
+        PrintClassification("PARTIAL - charges readable but recharge timing is secret")
+    elseif info.currentCharges and info.maxCharges then
+        PrintClassification("likely DIRECT - verify by consuming a charge and re-running")
+    end
+end
+
+------------------------------------------------------------------------
+-- Probe: run all
+------------------------------------------------------------------------
+
+function Probe:RunAll(chargeSpellID)
+    self:TargetCasting()
+    print(" ")
+    self:NameplateCount()
+    print(" ")
+    self:SpellCharges(chargeSpellID)
+end
+
+------------------------------------------------------------------------
+-- Slash command integration
+------------------------------------------------------------------------
+
+function Probe:HandleCommand(args)
+    local sub = args:match("^(%S+)") or "all"
+    sub = sub:lower()
+
+    if sub == "target" then
+        self:TargetCasting()
+    elseif sub == "plates" then
+        self:NameplateCount()
+    elseif sub == "charges" then
+        local spellID = tonumber(args:match("%S+%s+(%d+)"))
+        self:SpellCharges(spellID)
+    elseif sub == "all" then
+        local spellID = tonumber(args:match("%S+%s+(%d+)"))
+        self:RunAll(spellID)
+    elseif sub == "help" then
+        print("|cff00ff00[HF Probe]|r Signal validation commands:")
+        print("  /hf probe target   - Test UnitCastingInfo / UnitChannelInfo")
+        print("  /hf probe plates   - Test C_NamePlate.GetNamePlates")
+        print("  /hf probe charges [spellID]  - Test C_Spell.GetSpellCharges (default: Barbed Shot)")
+        print("  /hf probe all [spellID]      - Run all probes")
+    else
+        print("|cff00ff00[HF Probe]|r Unknown probe: " .. sub .. ". Use /hf probe help")
+    end
+end

--- a/docs/SIGNAL_VALIDATION.md
+++ b/docs/SIGNAL_VALIDATION.md
@@ -1,0 +1,93 @@
+# Signal Validation
+
+Tracks the validation status of shared hunter signal surfaces under Midnight.
+
+Each signal is tested in-game using `/hf probe` and classified per the scheme below. Results here are the source of truth for whether Engine conditions or future profiles may depend on a signal.
+
+## Classification Scheme
+
+| Classification | Meaning | Engine Action |
+|----------------|---------|---------------|
+| **DIRECT** | Non-secret, accurate, stable across contexts | Safe as hard dependency in rules |
+| **HEURISTIC** | Works but with caveats (e.g. CVar-dependent) | Use with documented assumptions |
+| **IMPOSSIBLE** | Secret, errors, or missing API | Cannot use; fallback only |
+| **UNKNOWN** | Not yet tested | Do not depend on |
+
+## Signal Matrix
+
+### Target Casting
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| API | `UnitCastingInfo("target")` / `UnitChannelInfo("target")` | |
+| pcall safe | | |
+| issecretvalue | | |
+| Value accuracy | | Test while target is casting |
+| Instance behavior | | Test in dungeon/raid |
+| **Classification** | **UNKNOWN** | |
+
+Engine condition: `target_casting` (Engine.lua)
+Fallback if unavailable: condition returns false, interrupt hints do not fire.
+
+### Nameplate Count
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| API | `C_NamePlate.GetNamePlates()` | |
+| Namespace present | | `C_NamePlate` exists? |
+| pcall safe | | |
+| Table issecretvalue | | Top-level table |
+| Entry token issecretvalue | | `plate.namePlateUnitToken` per entry |
+| UnitCanAttack issecretvalue | | Per hostile unit |
+| Hostile filter accuracy | | Pull 2+ mobs, verify count |
+| CVar sensitivity | | Test with different nameplate settings |
+| Instance behavior | | Test in dungeon/raid |
+| **Classification** | **UNKNOWN** | |
+
+Engine condition: `target_count` (Engine.lua)
+Fallback if unavailable: condition returns false, AoE PREFER rules do not fire, single-target AC passthrough.
+
+### Spell Charges
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| API | `C_Spell.GetSpellCharges(spellID)` | |
+| Test spell | Barbed Shot (217200) | |
+| pcall safe | | |
+| currentCharges secret | | |
+| maxCharges secret | | |
+| cooldownStartTime secret | | Recharge timing may be restricted |
+| cooldownDuration secret | | |
+| Real-time update | | Consume charge, re-probe |
+| **Classification** | **UNKNOWN** | |
+
+Engine condition: `spell_charges` (Engine.lua)
+Fallback if unavailable: condition returns false, charge-based timing rules do not fire. Cast-event timer heuristic remains as backup.
+
+## Runtime Cost
+
+| Signal | Call Pattern | Acceptable? |
+|--------|-------------|-------------|
+| UnitCastingInfo/UnitChannelInfo | Per queue update (0.1s) | Yes (single lookups) |
+| GetNamePlates | Per queue update (0.1s) | Yes if table small (<20). Consider caching per frame. |
+| GetSpellCharges | Per queue update per charge spell | Yes (single lookup) |
+
+## Probe Commands
+
+```
+/hf probe target          -- test target casting APIs
+/hf probe plates          -- test nameplate enumeration
+/hf probe charges [id]    -- test spell charges (default: Barbed Shot 217200)
+/hf probe all [id]        -- run all probes
+/hf probe help            -- list probe commands
+```
+
+## Test Contexts
+
+Record results from each context where tested:
+
+- [ ] Open world (solo, 1 target)
+- [ ] Open world (2+ hostile mobs)
+- [ ] Dungeon (trash pack)
+- [ ] Dungeon (boss - casting check)
+- [ ] Different nameplate CVar settings


### PR DESCRIPTION
## Summary

Shared signal validation groundwork for #6.

- **Engine.lua**: New `spell_charges` condition type wrapping `C_Spell.GetSpellCharges()` with pcall + `issecretvalue` safety. Retrofitted pcall + secret-value guards on existing `target_casting` and `target_count` conditions, including namespace guard for `C_NamePlate`.
- **SignalProbe.lua**: Diagnostic `/hf probe` harness for in-game validation of target casting, nameplate count (with per-entry secret checks), and spell charge APIs. Each probe prints raw values, secret status, and classification hints.
- **docs/SIGNAL_VALIDATION.md**: Test matrix with classification scheme, runtime cost table, and test context checklist.

## Test plan

- [ ] `/hf probe target` with target selected (idle + casting)
- [ ] `/hf probe plates` with 2+ hostile mobs pulled
- [ ] `/hf probe charges` with Barbed Shot talented
- [ ] `/hf probe all` runs all three without errors
- [ ] Verify addon loads cleanly after `/reload`
- [ ] Record results in `docs/SIGNAL_VALIDATION.md`