### PR TITLE
feat: Wild Thrash AoE rules for both BM profiles

### DIFF
--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -85,6 +85,13 @@ local Profile = {
             },
         },
 
+        -- Wild Thrash: AoE preference (below BA/WF rules, best-effort via PARTIAL nameplate count)
+        {
+            type = "PREFER",
+            spellID = 1264359, -- Wild Thrash
+            condition = { type = "target_count", op = ">=", value = 3 },
+        },
+
         -- Nature's Ally: never Kill Command twice in a row
         {
             type = "BLACKLIST_CONDITIONAL",

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -26,6 +26,13 @@ local Profile = {
         { type = "BLACKLIST", spellID = 982 },    -- Revive Pet
         { type = "BLACKLIST", spellID = 147362 }, -- Counter Shot (user preference)
 
+        -- Wild Thrash: highest AoE priority (PIN when 3+ hostile nameplates)
+        {
+            type = "PIN",
+            spellID = 1264359, -- Wild Thrash
+            condition = { type = "target_count", op = ">=", value = 3 },
+        },
+
         -- Bestial Wrath: suppress when on CD or when Barbed Shot charges remain
         {
             type = "BLACKLIST_CONDITIONAL",


### PR DESCRIPTION
## Summary

Adds Wild Thrash (1264359) AoE support to both BM hero path profiles using best-effort nameplate counting.

- **Pack Leader**: PIN Wild Thrash when `target_count >= 3` (highest AoE priority, per Icy Veins)
- **Dark Ranger**: PREFER Wild Thrash when `target_count >= 3` (below BA/WF rules)

Threshold 3 is conservative because `target_count` is PARTIAL -- counts all visible hostile nameplates, not only mobs in active combat. Degrades safely: if nameplate enumeration fails, condition returns false and AC passthrough handles the rotation.

## Test plan

- [ ] Pull 3+ mobs, `/hf debug` on Pack Leader -- Wild Thrash should appear in queue position 1
- [ ] Pull 3+ mobs, `/hf debug` on Dark Ranger -- Wild Thrash should appear below BA/WF overrides
- [ ] Single target -- Wild Thrash should not appear in queue overrides