### PR TITLE
fix: hero-path switch without /reload via SPELLS_CHANGED

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -69,6 +69,7 @@ eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
 eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 eventFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 eventFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
+eventFrame:RegisterEvent("SPELLS_CHANGED")
 eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
 
 eventFrame:SetScript("OnEvent", function(self, event, ...)
@@ -107,7 +108,8 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
         Engine:OnCombatEnd()
 
     elseif event == "PLAYER_SPECIALIZATION_CHANGED"
-        or event == "PLAYER_TALENT_UPDATE" then
+        or event == "PLAYER_TALENT_UPDATE"
+        or event == "SPELLS_CHANGED" then
         local prev = Engine.activeProfile
         TryActivate()
         local curr = Engine.activeProfile


### PR DESCRIPTION
## Summary

Fixes BM hero-path auto-switch not triggering on talent changes. `PLAYER_TALENT_UPDATE` does not fire on hero path changes; `SPELLS_CHANGED` does.

- Added `SPELLS_CHANGED` event registration
- Wired to existing re-detection path (`TryActivate()`)
- Event fires 2x on hero path switch; idempotent re-activation handles this cleanly

Confirmed in-game: `SPELLS_CHANGED` fires when switching between Dark Ranger and Pack Leader.

## Test plan

- [ ] Switch from Dark Ranger to Pack Leader without `/reload` -- "Profile switched: Hunter.BM.PackLeader" should appear in chat
- [ ] Switch back -- "Profile switched: Hunter.BM.DarkRanger" should appear
- [ ] `/hf debug` confirms correct profile state after switch