### PR TITLE
fix: preserve profile state on same-profile re-activation

### DIFF
--- a/Engine.lua
+++ b/Engine.lua
@@ -229,11 +229,15 @@ function Engine:ActivateProfile(specID)
         return false
     end
 
+    local prev = self.activeProfile
+
     -- Match by markerSpell (hero path detection via IsPlayerSpell)
     for _, profile in ipairs(candidates) do
         if profile.markerSpell and IsPlayerSpell(profile.markerSpell) then
             self.activeProfile = profile
-            if profile.ResetState then profile:ResetState() end
+            if profile ~= prev then
+                if profile.ResetState then profile:ResetState() end
+            end
             self:RebuildBlacklist()
             return true
         end
@@ -243,7 +247,9 @@ function Engine:ActivateProfile(specID)
     for _, profile in ipairs(candidates) do
         if not profile.markerSpell then
             self.activeProfile = profile
-            if profile.ResetState then profile:ResetState() end
+            if profile ~= prev then
+                if profile.ResetState then profile:ResetState() end
+            end
             self:RebuildBlacklist()
             return true
         end


### PR DESCRIPTION
## Summary

Fixes BW being recommended constantly on both BM profiles after the SPELLS_CHANGED event trigger was added in PR #16.

`SPELLS_CHANGED` fires frequently beyond talent switches. Each fire triggered `ActivateProfile` which unconditionally called `ResetState()`, wiping cast-event timers (`lastBWCast`, etc.). The profile then behaved as if BW had never been cast.

Fix: `ActivateProfile` now compares the selected profile against the current active profile. `ResetState()` is only called when the profile actually changes. Redundant re-activations preserve existing state.

## Test plan

- [ ] As Pack Leader: cast BW, verify it disappears from queue for ~29s
- [ ] Wait through several SPELLS_CHANGED cycles, confirm BW stays suppressed
- [ ] Switch hero path, confirm new profile gets a clean state reset