### PR TITLE
feat: add settings panel and recommendation feedback

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -15,11 +15,28 @@ local DEFAULTS = {
     iconSize = 40,
     iconSpacing = 4,
     locked = false,
+    showCooldownSwipe = true,
+    showCastFeedback = true,
 }
+
+local optionCallbacks = {}
 
 function HunterFlow.GetOpt(key)
     if HunterFlowDB[key] ~= nil then return HunterFlowDB[key] end
     return DEFAULTS[key]
+end
+
+function HunterFlow.SetOpt(key, value)
+    local prev = HunterFlow.GetOpt(key)
+    if prev == value then return end
+    HunterFlowDB[key] = value
+    for _, callback in ipairs(optionCallbacks) do
+        callback(key, value, prev)
+    end
+end
+
+function HunterFlow.RegisterOptCallback(callback)
+    optionCallbacks[#optionCallbacks + 1] = callback
 end
 
 ------------------------------------------------------------------------
@@ -81,7 +98,7 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
             local profile = Engine.activeProfile
             local name = profile and profile.id or "unknown"
             print("|cff00ff00[HunterFlow]|r loaded. Profile: " .. name)
-            print("|cffaaaaaa  /hf lock|unlock|burst|help|r")
+            print("|cffaaaaaa  /hf lock|unlock|options|burst|help|r")
         else
             local specID = GetActiveSpecID()
             if not HunterFlow.Profiles[specID or 0] then
@@ -95,6 +112,9 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
         local unit, _, spellID = ...
         if unit == "player" and spellID then
             Engine:OnSpellCast(spellID)
+            if Display and Display.OnSpellCastSucceeded then
+                Display:OnSpellCastSucceeded(spellID)
+            end
         end
 
     elseif event == "PLAYER_REGEN_DISABLED" then
@@ -132,12 +152,12 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
     msg = msg:lower():trim()
 
     if msg == "lock" then
-        HunterFlowDB.locked = true
+        HunterFlow.SetOpt("locked", true)
         Display:SetClickThrough(true)
         print("|cff00ff00[HF]|r Frame locked (click-through).")
 
     elseif msg == "unlock" then
-        HunterFlowDB.locked = false
+        HunterFlow.SetOpt("locked", false)
         Display:SetClickThrough(false)
         print("|cff00ff00[HF]|r Frame unlocked. Drag to reposition.")
 
@@ -155,6 +175,13 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
 
     elseif msg == "show" then
         Display:Enable()
+
+    elseif msg == "options" or msg == "config" then
+        if HunterFlow.OpenSettingsPanel then
+            HunterFlow.OpenSettingsPanel()
+        else
+            print("|cffff0000[HF]|r Settings panel unavailable.")
+        end
 
     elseif msg == "debug" then
         local queue = Engine:ComputeQueue(HunterFlow.GetOpt("iconCount"))
@@ -181,6 +208,7 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
         print("|cff00ff00[HunterFlow]|r Commands:")
         print("  /hf lock    - Lock frame (click-through)")
         print("  /hf unlock  - Unlock frame for dragging")
+        print("  /hf options - Open the HunterFlow settings panel")
         print("  /hf burst   - Toggle burst mode")
         print("  /hf hide    - Hide the display")
         print("  /hf show    - Show the display")

--- a/Display.lua
+++ b/Display.lua
@@ -1,9 +1,15 @@
 -- HunterFlow Display: presentation layer for the queue overlay
 
 local Engine = HunterFlow.Engine
+local GetTime = GetTime
+local C_Spell_GetSpellTexture = C_Spell and C_Spell.GetSpellTexture
+local C_Spell_GetSpellCooldown = C_Spell and C_Spell.GetSpellCooldown
 
 HunterFlow.Display = {}
 local Display = HunterFlow.Display
+
+local SUCCESS_FLASH_DURATION = 0.35
+local MIN_COOLDOWN_SWIPE_DURATION = 2.0
 
 ------------------------------------------------------------------------
 -- Container frame
@@ -31,6 +37,16 @@ Display.container = container
 ------------------------------------------------------------------------
 
 local icons = {}
+
+local function ClearCooldown(icon)
+    if not icon or not icon.cooldown then return end
+    if icon.cooldown.Clear then
+        icon.cooldown:Clear()
+    elseif icon.cooldown.SetCooldown then
+        icon.cooldown:SetCooldown(0, 0)
+    end
+    icon.cooldown:Hide()
+end
 
 local function GetKeybindForSpell(spellID)
     for slot = 1, 120 do
@@ -66,11 +82,26 @@ local function CreateIcon(index)
     frame.texture:SetAllPoints()
     frame.texture:SetTexCoord(0.07, 0.93, 0.07, 0.93)
 
+    frame.cooldown = CreateFrame("Cooldown", nil, frame, "CooldownFrameTemplate")
+    frame.cooldown:SetAllPoints(frame)
+    frame.cooldown:SetHideCountdownNumbers(true)
+    if frame.cooldown.SetDrawBling then frame.cooldown:SetDrawBling(false) end
+    if frame.cooldown.SetDrawEdge then frame.cooldown:SetDrawEdge(false) end
+    if frame.cooldown.SetSwipeColor then frame.cooldown:SetSwipeColor(0, 0, 0, 0.8) end
+    frame.cooldown:Hide()
+
     frame.keybind = frame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmallGray")
     frame.keybind:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -2, -2)
     frame.keybind:SetJustifyH("RIGHT")
 
-    -- TODO: GCD sweep needs SecureDelegate research
+    frame.success = frame:CreateTexture(nil, "OVERLAY")
+    frame.success:SetAllPoints()
+    frame.success:SetAtlas("UI-HUD-ActionBar-IconFrame-Mouseover")
+    frame.success:SetVertexColor(0.20, 1.00, 0.35, 1.0)
+    frame.success:SetBlendMode("ADD")
+    frame.success:Hide()
+    frame.successUntil = 0
+    frame.spellID = nil
 
     frame.border = frame:CreateTexture(nil, "OVERLAY")
     frame.border:SetAllPoints()
@@ -82,6 +113,21 @@ local function CreateIcon(index)
 
     frame:Hide()
     return frame
+end
+
+local function LayoutIcons()
+    local size = HunterFlow.GetOpt("iconSize")
+    local spacing = HunterFlow.GetOpt("iconSpacing")
+    for index, frame in ipairs(icons) do
+        frame:SetSize(size, size)
+        frame:ClearAllPoints()
+        frame:SetPoint("LEFT", container, "LEFT", (index - 1) * (size + spacing), 0)
+        if index > 1 then
+            frame:SetAlpha(0.7)
+        else
+            frame:SetAlpha(1)
+        end
+    end
 end
 
 local function EnsureIcons()
@@ -96,28 +142,112 @@ function Display:UpdateContainerSize()
     local size = HunterFlow.GetOpt("iconSize")
     local spacing = HunterFlow.GetOpt("iconSpacing")
     container:SetSize(count * size + (count - 1) * spacing, size)
+    LayoutIcons()
+end
+
+function Display:ApplyOptions()
+    self:UpdateContainerSize()
+    container:EnableMouse(not HunterFlow.GetOpt("locked"))
+end
+
+function Display:UpdateCooldown(icon, spellID)
+    if not icon or not icon.cooldown then return end
+    if not HunterFlow.GetOpt("showCooldownSwipe") or not spellID or not C_Spell_GetSpellCooldown then
+        ClearCooldown(icon)
+        return
+    end
+
+    local ok, cooldown = pcall(C_Spell_GetSpellCooldown, spellID)
+    if not ok or not cooldown then
+        ClearCooldown(icon)
+        return
+    end
+
+    local startTime = cooldown.startTime or 0
+    local duration = cooldown.duration or 0
+
+    if issecretvalue and (issecretvalue(startTime) or issecretvalue(duration)) then
+        ClearCooldown(icon)
+        return
+    end
+
+    if startTime <= 0 or duration < MIN_COOLDOWN_SWIPE_DURATION then
+        ClearCooldown(icon)
+        return
+    end
+
+    if icon.cooldown.SetCooldown then
+        icon.cooldown:SetCooldown(startTime, duration, cooldown.modRate or 1)
+    end
+    icon.cooldown:Show()
+end
+
+function Display:UpdateCastFeedback(icon, now)
+    if not icon or not icon.success then return end
+    if not HunterFlow.GetOpt("showCastFeedback") then
+        icon.success:Hide()
+        icon.successUntil = 0
+        return
+    end
+
+    if icon.successUntil > now then
+        local remaining = icon.successUntil - now
+        icon.success:SetAlpha(remaining / SUCCESS_FLASH_DURATION)
+        icon.success:Show()
+    else
+        icon.success:Hide()
+    end
 end
 
 function Display:UpdateQueue(queue)
     EnsureIcons()
     local count = HunterFlow.GetOpt("iconCount")
+    local now = GetTime()
 
     for i = 1, count do
         local icon = icons[i]
         local spellID = queue[i]
 
         if spellID then
-            local texture = C_Spell.GetSpellTexture(spellID)
+            local texture = C_Spell_GetSpellTexture and C_Spell_GetSpellTexture(spellID)
             if texture then
                 icon.texture:SetTexture(texture)
                 local key = GetKeybindForSpell(spellID)
                 icon.keybind:SetText(key or "")
+                icon.spellID = spellID
+                self:UpdateCooldown(icon, spellID)
+                self:UpdateCastFeedback(icon, now)
                 icon:Show()
             else
+                icon.spellID = nil
+                ClearCooldown(icon)
+                icon.success:Hide()
                 icon:Hide()
             end
         else
+            icon.spellID = nil
+            ClearCooldown(icon)
+            icon.success:Hide()
             icon:Hide()
+        end
+    end
+
+    for i = count + 1, #icons do
+        local icon = icons[i]
+        icon.spellID = nil
+        ClearCooldown(icon)
+        icon.success:Hide()
+        icon:Hide()
+    end
+end
+
+function Display:OnSpellCastSucceeded(spellID)
+    if not HunterFlow.GetOpt("showCastFeedback") then return end
+    local now = GetTime()
+    for _, icon in ipairs(icons) do
+        if icon.spellID == spellID then
+            icon.successUntil = now + SUCCESS_FLASH_DURATION
+            self:UpdateCastFeedback(icon, now)
         end
     end
 end
@@ -130,7 +260,7 @@ local UPDATE_INTERVAL = 0.1
 local timeSinceUpdate = 0
 
 function Display:Enable()
-    self:UpdateContainerSize()
+    self:ApplyOptions()
     EnsureIcons()
     container:EnableMouse(not HunterFlow.GetOpt("locked"))
     container:Show()
@@ -152,3 +282,12 @@ end
 function Display:SetClickThrough(locked)
     container:EnableMouse(not locked)
 end
+
+function Display:ResetPosition()
+    container:ClearAllPoints()
+    container:SetPoint("CENTER", UIParent, "CENTER", 0, -50)
+end
+
+HunterFlow.RegisterOptCallback(function()
+    Display:ApplyOptions()
+end)

--- a/HunterFlow.toc
+++ b/HunterFlow.toc
@@ -8,6 +8,7 @@
 Engine.lua
 Profiles/BM_DarkRanger.lua
 Profiles/BM_PackLeader.lua
-Display.lua
-SignalProbe.lua
 Core.lua
+Display.lua
+SettingsPanel.lua
+SignalProbe.lua

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ Planned direction:
 - Supports BM-specific cast-tracked state (Dark Ranger: Black Arrow, Bestial Wrath, Wailing Arrow; Pack Leader: BW management, Wild Thrash AoE)
 - Nature's Ally Kill Command weaving (both profiles)
 - Barbed Shot charge dump before Bestial Wrath (validated via `C_Spell.GetSpellCharges`)
+- Shows cast-success feedback when a displayed recommendation is actually cast
+- Supports best-effort cooldown swipes for readable non-GCD lockouts
 - Keeps interrupt logic out of the primary queue by default
 - Supports click-through while locked
+- Registers a native `HunterFlow` category in the in-game Settings UI
 
 ## Design Constraints
 
@@ -73,6 +76,7 @@ They describe the target architecture, not a claim that the current alpha is alr
 
 - `/hf lock`
 - `/hf unlock`
+- `/hf options`
 - `/hf burst`
 - `/hf hide`
 - `/hf show`

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -1,0 +1,135 @@
+-- HunterFlow Settings: native Game Options category for lightweight addon config
+
+HunterFlow = HunterFlow or {}
+
+local settingsCategory
+
+local function OpenRegisteredCategory()
+    if not settingsCategory or not Settings or not Settings.OpenToCategory then return end
+    if settingsCategory.GetID then
+        Settings.OpenToCategory(settingsCategory:GetID())
+    elseif settingsCategory.ID then
+        Settings.OpenToCategory(settingsCategory.ID)
+    else
+        Settings.OpenToCategory("HunterFlow")
+    end
+end
+
+local function CreateCheckbox(parent, label, description, relativeTo, x, y, key)
+    local check = CreateFrame("CheckButton", nil, parent, "InterfaceOptionsCheckButtonTemplate")
+    check:SetPoint("TOPLEFT", relativeTo, "BOTTOMLEFT", x, y)
+    check.Text:SetText(label)
+
+    local desc = parent:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    desc:SetPoint("TOPLEFT", check.Text, "BOTTOMLEFT", 0, -2)
+    desc:SetPoint("RIGHT", parent, "RIGHT", -24, 0)
+    desc:SetJustifyH("LEFT")
+    desc:SetText(description)
+
+    check:SetScript("OnClick", function(self)
+        HunterFlow.SetOpt(key, self:GetChecked() and true or false)
+        if key == "locked" and HunterFlow.Display and HunterFlow.Display.SetClickThrough then
+            HunterFlow.Display:SetClickThrough(self:GetChecked())
+        end
+    end)
+
+    check.sync = function()
+        check:SetChecked(HunterFlow.GetOpt(key))
+    end
+
+    return check, desc
+end
+
+local function CreateSettingsPanel()
+    local panel = CreateFrame("Frame", "HunterFlowSettingsPanel", UIParent)
+    panel.name = "HunterFlow"
+    panel:SetSize(640, 480)
+
+    local title = panel:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
+    title:SetPoint("TOPLEFT", panel, "TOPLEFT", 16, -16)
+    title:SetText("HunterFlow")
+
+    local subtitle = panel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    subtitle:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
+    subtitle:SetPoint("RIGHT", panel, "RIGHT", -16, 0)
+    subtitle:SetJustifyH("LEFT")
+    subtitle:SetText("Midnight-compatible hunter overlay on top of Blizzard Assisted Combat. Keep the panel lean: settings here should stay practical and low-overhead.")
+
+    local lockCheck, lockDesc = CreateCheckbox(
+        panel,
+        "Lock overlay frame",
+        "Disable dragging and make the overlay click-through during combat.",
+        subtitle, 0, -18, "locked"
+    )
+
+    local castCheck, castDesc = CreateCheckbox(
+        panel,
+        "Show cast success feedback",
+        "Flash the recommended icon briefly when your successful cast matches the displayed recommendation.",
+        lockDesc, 0, -18, "showCastFeedback"
+    )
+
+    local cooldownCheck = CreateFrame("CheckButton", nil, panel, "InterfaceOptionsCheckButtonTemplate")
+    cooldownCheck:SetPoint("TOPLEFT", castDesc, "BOTTOMLEFT", 0, -18)
+    cooldownCheck.Text:SetText("Show cooldown swipes (best-effort)")
+
+    local cooldownDesc = panel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    cooldownDesc:SetPoint("TOPLEFT", cooldownCheck.Text, "BOTTOMLEFT", 0, -2)
+    cooldownDesc:SetPoint("RIGHT", panel, "RIGHT", -24, 0)
+    cooldownDesc:SetJustifyH("LEFT")
+    cooldownDesc:SetText("Use readable spell cooldown data when available and suppress obvious GCD-only churn. This is visual feedback, not a promise of exact Midnight cooldown truth.")
+
+    cooldownCheck:SetScript("OnClick", function(self)
+        HunterFlow.SetOpt("showCooldownSwipe", self:GetChecked() and true or false)
+    end)
+
+    local unlockButton = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
+    unlockButton:SetSize(160, 24)
+    unlockButton:SetPoint("TOPLEFT", cooldownDesc, "BOTTOMLEFT", 0, -18)
+    unlockButton:SetText("Unlock And Recenter")
+    unlockButton:SetScript("OnClick", function()
+        HunterFlow.SetOpt("locked", false)
+        if HunterFlow.Display and HunterFlow.Display.ResetPosition then
+            HunterFlow.Display:ResetPosition()
+            HunterFlow.Display:SetClickThrough(false)
+        end
+        lockCheck:SetChecked(false)
+    end)
+
+    local hint = panel:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
+    hint:SetPoint("TOPLEFT", unlockButton, "BOTTOMLEFT", 0, -10)
+    hint:SetPoint("RIGHT", panel, "RIGHT", -24, 0)
+    hint:SetJustifyH("LEFT")
+    hint:SetText("For profile logic and diagnostics, keep using `/hf debug` and `/hf probe`. This panel is only for persistent UI behavior.")
+
+    panel:SetScript("OnShow", function()
+        lockCheck.sync()
+        castCheck.sync()
+        cooldownCheck:SetChecked(HunterFlow.GetOpt("showCooldownSwipe"))
+    end)
+
+    return panel
+end
+
+local function RegisterSettingsPanel()
+    if settingsCategory or not Settings or not Settings.RegisterCanvasLayoutCategory or not Settings.RegisterAddOnCategory then
+        return
+    end
+
+    local panel = CreateSettingsPanel()
+    settingsCategory = Settings.RegisterCanvasLayoutCategory(panel, "HunterFlow")
+    Settings.RegisterAddOnCategory(settingsCategory)
+end
+
+function HunterFlow.OpenSettingsPanel()
+    RegisterSettingsPanel()
+    OpenRegisteredCategory()
+end
+
+RegisterSettingsPanel()
+
+local initFrame = CreateFrame("Frame")
+initFrame:RegisterEvent("PLAYER_LOGIN")
+initFrame:SetScript("OnEvent", function()
+    RegisterSettingsPanel()
+end)


### PR DESCRIPTION
## Summary

Adds a lightweight UX expansion for HunterFlow's live queue overlay:

- registers a native `HunterFlow` category in the in-game Settings UI
- adds `/hf options` to open the settings panel quickly
- flashes a displayed recommendation briefly when the player successfully casts that spell
- adds best-effort cooldown swipes for readable non-GCD lockouts
- documents the new UI behavior in the README

The cooldown display is intentionally conservative: it suppresses obvious short GCD-only churn and hides itself when readable cooldown data is not safely available.

## Verification

- `luac -p Core.lua Display.lua SettingsPanel.lua SignalProbe.lua Profiles/BM_DarkRanger.lua Profiles/BM_PackLeader.lua Engine.lua`
- local review of load order, callback wiring, and Settings registration flow
- local review of the cooldown-swipe guardrails against Midnight constraints

## Follow-up

- in-game polish / feel tuning can happen after live feedback if the flash or cooldown visuals need adjustment
