### PR TITLE
feat: Why overlay showing recommendation reason (#20)

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -15,8 +15,10 @@ local DEFAULTS = {
     iconSize = 40,
     iconSpacing = 4,
     locked = false,
+    enableDiagnostics = false,
     showCooldownSwipe = true,
     showCastFeedback = true,
+    showWhyOverlay = false,
 }
 
 local optionCallbacks = {}
@@ -37,6 +39,10 @@ end
 
 function HunterFlow.RegisterOptCallback(callback)
     optionCallbacks[#optionCallbacks + 1] = callback
+end
+
+function HunterFlow.DiagnosticsEnabled()
+    return HunterFlow.GetOpt("enableDiagnostics") and true or false
 end
 
 ------------------------------------------------------------------------
@@ -183,6 +189,19 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
             print("|cffff0000[HF]|r Settings panel unavailable.")
         end
 
+    elseif msg == "diagnostics on" or msg == "diag on" then
+        HunterFlow.SetOpt("enableDiagnostics", true)
+        print("|cff00ff00[HF]|r Diagnostics enabled. `/hf probe ...` is now available.")
+
+    elseif msg == "diagnostics off" or msg == "diag off" then
+        HunterFlow.SetOpt("enableDiagnostics", false)
+        print("|cff00ff00[HF]|r Diagnostics disabled.")
+
+    elseif msg == "diagnostics" or msg == "diag" then
+        local state = HunterFlow.DiagnosticsEnabled() and "ON" or "OFF"
+        print("|cff00ff00[HF]|r Diagnostics: " .. state)
+        print("  Use `/hf diagnostics on` or `/hf diagnostics off`.")
+
     elseif msg == "debug" then
         local queue = Engine:ComputeQueue(HunterFlow.GetOpt("iconCount"))
         print("|cff00ff00[HF] Queue:|r")
@@ -201,6 +220,10 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
         print("  Burst mode: " .. tostring(Engine.burstModeActive))
 
     elseif msg:sub(1, 5) == "probe" then
+        if not HunterFlow.DiagnosticsEnabled() then
+            print("|cffffff00[HF]|r Probe diagnostics are disabled. Enable them via `/hf diagnostics on` or in `/hf options`.")
+            return
+        end
         local probeArgs = msg:sub(7) or ""
         HunterFlow.SignalProbe:HandleCommand(probeArgs)
 
@@ -213,7 +236,8 @@ SlashCmdList["HUNTERFLOW"] = function(msg)
         print("  /hf hide    - Hide the display")
         print("  /hf show    - Show the display")
         print("  /hf debug   - Print queue and profile state")
-        print("  /hf probe   - Signal validation probes (probe help for details)")
+        print("  /hf diagnostics on|off - Enable or disable probe diagnostics")
+        print("  /hf probe   - Signal validation probes (only when diagnostics are enabled)")
 
     else
         print("|cff00ff00[HunterFlow]|r Use /hf help for commands.")

--- a/Display.lua
+++ b/Display.lua
@@ -10,6 +10,9 @@ local Display = HunterFlow.Display
 
 local SUCCESS_FLASH_DURATION = 0.35
 local MIN_COOLDOWN_SWIPE_DURATION = 2.0
+local CONTAINER_PADDING_X = 8
+local CONTAINER_PADDING_Y = 6
+local ICON_TEXTURE_INSET = 3
 
 ------------------------------------------------------------------------
 -- Container frame
@@ -29,8 +32,28 @@ end)
 container:SetScript("OnDragStop", function(self)
     self:StopMovingOrSizing()
 end)
+container:SetBackdrop({
+    bgFile = "Interface/Tooltips/UI-Tooltip-Background",
+    edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
+    edgeSize = 12,
+    insets = { left = 3, right = 3, top = 3, bottom = 3 },
+})
+container:SetBackdropColor(0.04, 0.04, 0.04, 0.92)
+container:SetBackdropBorderColor(0.55, 0.55, 0.55, 0.95)
+
+local content = CreateFrame("Frame", nil, container)
+content:SetPoint("TOPLEFT", container, "TOPLEFT", CONTAINER_PADDING_X, -CONTAINER_PADDING_Y)
+content:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -CONTAINER_PADDING_X, CONTAINER_PADDING_Y)
 
 Display.container = container
+
+container:SetClipsChildren(false)
+
+local reasonText = container:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+reasonText:SetPoint("TOP", container, "BOTTOM", 0, -2)
+reasonText:SetJustifyH("CENTER")
+reasonText:SetTextColor(0.75, 0.85, 1.0, 0.9)
+reasonText:Hide()
 
 ------------------------------------------------------------------------
 -- Icons
@@ -73,17 +96,34 @@ local function CreateIcon(index)
     local spacing = HunterFlow.GetOpt("iconSpacing")
 
     local frame = CreateFrame("Frame", "HunterFlowIcon" .. index,
-        container, "BackdropTemplate")
+        content)
     frame:SetSize(size, size)
-    frame:SetPoint("LEFT", container, "LEFT",
+    frame:SetPoint("LEFT", content, "LEFT",
         (index - 1) * (size + spacing), 0)
 
+    frame.slotBackground = frame:CreateTexture(nil, "BACKGROUND")
+    frame.slotBackground:SetAllPoints()
+    frame.slotBackground:SetAtlas("UI-HUD-ActionBar-IconFrame-Background")
+
     frame.texture = frame:CreateTexture(nil, "ARTWORK")
-    frame.texture:SetAllPoints()
+    frame.texture:SetPoint("TOPLEFT", frame, "TOPLEFT", ICON_TEXTURE_INSET, -ICON_TEXTURE_INSET)
+    frame.texture:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -ICON_TEXTURE_INSET, ICON_TEXTURE_INSET)
     frame.texture:SetTexCoord(0.07, 0.93, 0.07, 0.93)
 
+    if frame.CreateMaskTexture and frame.texture.AddMaskTexture and frame.slotBackground.AddMaskTexture then
+        local mask = frame:CreateMaskTexture(nil, "ARTWORK")
+        mask:SetPoint("TOPLEFT", frame, "TOPLEFT", -6, 6)
+        mask:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 6, -6)
+        mask:SetAtlas("UI-HUD-ActionBar-IconFrame-Mask", false)
+        frame.texture:AddMaskTexture(mask)
+        frame.slotBackground:AddMaskTexture(mask)
+        frame.mask = mask
+    end
+
     frame.cooldown = CreateFrame("Cooldown", nil, frame, "CooldownFrameTemplate")
-    frame.cooldown:SetAllPoints(frame)
+    frame.cooldown:ClearAllPoints()
+    frame.cooldown:SetPoint("TOPLEFT", frame, "TOPLEFT", ICON_TEXTURE_INSET, -ICON_TEXTURE_INSET)
+    frame.cooldown:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -ICON_TEXTURE_INSET, ICON_TEXTURE_INSET)
     frame.cooldown:SetHideCountdownNumbers(true)
     if frame.cooldown.SetDrawBling then frame.cooldown:SetDrawBling(false) end
     if frame.cooldown.SetDrawEdge then frame.cooldown:SetDrawEdge(false) end
@@ -121,7 +161,7 @@ local function LayoutIcons()
     for index, frame in ipairs(icons) do
         frame:SetSize(size, size)
         frame:ClearAllPoints()
-        frame:SetPoint("LEFT", container, "LEFT", (index - 1) * (size + spacing), 0)
+        frame:SetPoint("LEFT", content, "LEFT", (index - 1) * (size + spacing), 0)
         if index > 1 then
             frame:SetAlpha(0.7)
         else
@@ -141,7 +181,12 @@ function Display:UpdateContainerSize()
     local count = HunterFlow.GetOpt("iconCount")
     local size = HunterFlow.GetOpt("iconSize")
     local spacing = HunterFlow.GetOpt("iconSpacing")
-    container:SetSize(count * size + (count - 1) * spacing, size)
+    local width = count * size + (count - 1) * spacing
+    container:SetSize(
+        width + (CONTAINER_PADDING_X * 2),
+        size + (CONTAINER_PADDING_Y * 2)
+    )
+    content:SetSize(width, size)
     LayoutIcons()
 end
 
@@ -238,6 +283,19 @@ function Display:UpdateQueue(queue)
         ClearCooldown(icon)
         icon.success:Hide()
         icon:Hide()
+    end
+
+    -- Why overlay: show reason for position 1
+    if HunterFlow.GetOpt("showWhyOverlay") then
+        local meta = Engine.lastQueueMeta
+        if meta and meta.reason then
+            reasonText:SetText(meta.reason)
+            reasonText:Show()
+        else
+            reasonText:Hide()
+        end
+    else
+        reasonText:Hide()
     end
 end
 

--- a/Engine.lua
+++ b/Engine.lua
@@ -9,6 +9,7 @@ local Engine = HunterFlow.Engine
 Engine.burstModeActive = false
 Engine.combatStartTime = nil
 Engine.activeProfile = nil
+Engine.lastQueueMeta = { source = "ac", reason = nil }
 
 local function IsSecret(val)
     return issecretvalue and issecretvalue(val) or false
@@ -129,9 +130,13 @@ end
 function Engine:ComputeQueue(iconCount)
     local queue = {}
     local profile = self.activeProfile
-    if not profile then return queue end
+    if not profile then
+        self.lastQueueMeta = { source = "ac", reason = nil }
+        return queue
+    end
 
     if not C_AssistedCombat or not C_AssistedCombat.IsAvailable() then
+        self.lastQueueMeta = { source = "ac", reason = nil }
         return queue
     end
 
@@ -151,10 +156,12 @@ function Engine:ComputeQueue(iconCount)
 
     -- PIN rules (highest priority, first match wins)
     local pinnedSpell = nil
+    local firedRule = nil
     for _, rule in ipairs(profile.rules) do
         if rule.type == "PIN" and self:EvalCondition(rule.condition) then
             if self:IsSpellCastable(rule.spellID) and not IsBlocked(rule.spellID) then
                 pinnedSpell = rule.spellID
+                firedRule = rule
                 break
             end
         end
@@ -167,6 +174,7 @@ function Engine:ComputeQueue(iconCount)
             if rule.type == "PREFER" and self:EvalCondition(rule.condition) then
                 if self:IsSpellCastable(rule.spellID) and not IsBlocked(rule.spellID) then
                     preferredSpell = rule.spellID
+                    firedRule = rule
                     break
                 end
             end
@@ -178,6 +186,16 @@ function Engine:ComputeQueue(iconCount)
     local pos1 = pinnedSpell or preferredSpell or baseSpell
     if pos1 and not IsBlocked(pos1) then
         queue[#queue + 1] = pos1
+    end
+
+    -- Store metadata for display features
+    if firedRule then
+        self.lastQueueMeta = {
+            source = firedRule.type == "PIN" and "pin" or "prefer",
+            reason = firedRule.reason,
+        }
+    else
+        self.lastQueueMeta = { source = "ac", reason = nil }
     end
 
     -- Positions 2+ from GetRotationSpells()

--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -45,6 +45,7 @@ local Profile = {
         {
             type = "PREFER",
             spellID = 217200, -- Barbed Shot
+            reason = "Charge Dump",
             condition = {
                 type = "and",
                 left  = { type = "spell_charges", spellID = 217200, op = ">", value = 0 },
@@ -56,6 +57,7 @@ local Profile = {
         {
             type = "PIN",
             spellID = 466930, -- Black Arrow
+            reason = "Withering Fire",
             condition = {
                 type = "and",
                 left  = { type = "ba_ready" },
@@ -67,6 +69,7 @@ local Profile = {
         {
             type = "PREFER",
             spellID = 392060, -- Wailing Arrow
+            reason = "WF Ending",
             condition = {
                 type = "and",
                 left  = { type = "wa_available" },
@@ -78,6 +81,7 @@ local Profile = {
         {
             type = "PREFER",
             spellID = 466930, -- Black Arrow
+            reason = "BA Ready",
             condition = {
                 type = "and",
                 left  = { type = "ba_ready" },
@@ -89,6 +93,7 @@ local Profile = {
         {
             type = "PREFER",
             spellID = 1264359, -- Wild Thrash
+            reason = "AoE 3+",
             condition = { type = "target_count", op = ">=", value = 3 },
         },
 

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -30,6 +30,7 @@ local Profile = {
         {
             type = "PIN",
             spellID = 1264359, -- Wild Thrash
+            reason = "AoE 3+",
             condition = { type = "target_count", op = ">=", value = 3 },
         },
 
@@ -48,6 +49,7 @@ local Profile = {
         {
             type = "PREFER",
             spellID = 217200, -- Barbed Shot
+            reason = "Charge Dump",
             condition = {
                 type = "and",
                 left  = { type = "spell_charges", spellID = 217200, op = ">", value = 0 },

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Planned direction:
 - Keeps interrupt logic out of the primary queue by default
 - Supports click-through while locked
 - Registers a native `HunterFlow` category in the in-game Settings UI
+- Keeps signal probe diagnostics disabled by default unless you explicitly enable them
 
 ## Design Constraints
 
@@ -81,6 +82,8 @@ They describe the target architecture, not a claim that the current alpha is alr
 - `/hf hide`
 - `/hf show`
 - `/hf debug`
+- `/hf diagnostics on|off`
+- `/hf probe ...` (only when diagnostics are enabled)
 - `/hunterflow`
 
 ## Installation

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -83,9 +83,23 @@ local function CreateSettingsPanel()
         HunterFlow.SetOpt("showCooldownSwipe", self:GetChecked() and true or false)
     end)
 
+    local whyCheck, whyDesc = CreateCheckbox(
+        panel,
+        "Show recommendation reason",
+        "Display a short label below the primary icon explaining why it was recommended (e.g. Withering Fire, Charge Dump, AoE). Hidden when Assisted Combat passthrough is active.",
+        cooldownDesc, 0, -18, "showWhyOverlay"
+    )
+
+    local diagnosticsCheck, diagnosticsDesc = CreateCheckbox(
+        panel,
+        "Enable probe diagnostics",
+        "Keep the heavier signal probe commands off by default. Turn this on only when you explicitly want `/hf probe ...` for API validation or debugging.",
+        whyDesc, 0, -18, "enableDiagnostics"
+    )
+
     local unlockButton = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
     unlockButton:SetSize(160, 24)
-    unlockButton:SetPoint("TOPLEFT", cooldownDesc, "BOTTOMLEFT", 0, -18)
+    unlockButton:SetPoint("TOPLEFT", diagnosticsDesc, "BOTTOMLEFT", 0, -18)
     unlockButton:SetText("Unlock And Recenter")
     unlockButton:SetScript("OnClick", function()
         HunterFlow.SetOpt("locked", false)
@@ -100,12 +114,14 @@ local function CreateSettingsPanel()
     hint:SetPoint("TOPLEFT", unlockButton, "BOTTOMLEFT", 0, -10)
     hint:SetPoint("RIGHT", panel, "RIGHT", -24, 0)
     hint:SetJustifyH("LEFT")
-    hint:SetText("For profile logic and diagnostics, keep using `/hf debug` and `/hf probe`. This panel is only for persistent UI behavior.")
+    hint:SetText("For profile logic, keep using `/hf debug`. Probe commands stay behind the diagnostics toggle above, or `/hf diagnostics on`, so they only run when you explicitly need them.")
 
     panel:SetScript("OnShow", function()
         lockCheck.sync()
         castCheck.sync()
         cooldownCheck:SetChecked(HunterFlow.GetOpt("showCooldownSwipe"))
+        whyCheck.sync()
+        diagnosticsCheck.sync()
     end)
 
     return panel


### PR DESCRIPTION
## Summary

Adds an optional text label below the primary queue icon explaining why a spell was recommended. Off by default, toggleable in `/hf options`.

- Engine stores `lastQueueMeta` (source + reason) during `ComputeQueue`
- Rules in both BM profiles have `reason` labels (Withering Fire, Charge Dump, AoE 3+, etc.)
- Display renders reason text below primary icon, hidden during AC passthrough
- Meta cleared on early exits to prevent stale labels

## Test plan

- [ ] Enable "Show recommendation reason" in `/hf options`
- [ ] During Withering Fire: "Withering Fire" label below BA icon
- [ ] During charge dump phase: "Charge Dump" below Barbed Shot
- [ ] Normal AC passthrough: no label shown
- [ ] Toggle off: label disappears