### PR TITLE
feat: phase indicator and AC override transparency (#21, #22)

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -19,6 +19,8 @@ local DEFAULTS = {
     showCooldownSwipe = true,
     showCastFeedback = true,
     showWhyOverlay = false,
+    showPhaseIndicator = false,
+    showOverrideIndicator = false,
 }
 
 local optionCallbacks = {}

--- a/Display.lua
+++ b/Display.lua
@@ -55,6 +55,12 @@ reasonText:SetJustifyH("CENTER")
 reasonText:SetTextColor(0.75, 0.85, 1.0, 0.9)
 reasonText:Hide()
 
+local phaseText = container:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+phaseText:SetPoint("BOTTOM", container, "TOP", 0, 2)
+phaseText:SetJustifyH("CENTER")
+phaseText:SetTextColor(1.0, 0.82, 0.0, 0.9)
+phaseText:Hide()
+
 ------------------------------------------------------------------------
 -- Icons
 ------------------------------------------------------------------------
@@ -285,17 +291,33 @@ function Display:UpdateQueue(queue)
         icon:Hide()
     end
 
+    local meta = Engine.lastQueueMeta
+
     -- Why overlay: show reason for position 1
-    if HunterFlow.GetOpt("showWhyOverlay") then
-        local meta = Engine.lastQueueMeta
-        if meta and meta.reason then
-            reasonText:SetText(meta.reason)
-            reasonText:Show()
-        else
-            reasonText:Hide()
-        end
+    if HunterFlow.GetOpt("showWhyOverlay") and meta and meta.reason then
+        reasonText:SetText(meta.reason)
+        reasonText:Show()
     else
         reasonText:Hide()
+    end
+
+    -- Phase indicator: show current rotation phase above overlay
+    if HunterFlow.GetOpt("showPhaseIndicator") and meta and meta.phase then
+        phaseText:SetText(meta.phase)
+        phaseText:Show()
+    else
+        phaseText:Hide()
+    end
+
+    -- Override indicator: tint primary icon border when HunterFlow overrides AC
+    if HunterFlow.GetOpt("showOverrideIndicator") and icons[1] and icons[1].border then
+        if meta and (meta.source == "pin" or meta.source == "prefer") then
+            icons[1].border:SetVertexColor(0.30, 0.85, 1.0, 1.0)
+        else
+            icons[1].border:SetVertexColor(1.0, 1.0, 1.0, 1.0)
+        end
+    elseif icons[1] and icons[1].border then
+        icons[1].border:SetVertexColor(1.0, 1.0, 1.0, 1.0)
     end
 end
 

--- a/Engine.lua
+++ b/Engine.lua
@@ -131,12 +131,12 @@ function Engine:ComputeQueue(iconCount)
     local queue = {}
     local profile = self.activeProfile
     if not profile then
-        self.lastQueueMeta = { source = "ac", reason = nil }
+        self.lastQueueMeta = { source = "ac", reason = nil, phase = nil }
         return queue
     end
 
     if not C_AssistedCombat or not C_AssistedCombat.IsAvailable() then
-        self.lastQueueMeta = { source = "ac", reason = nil }
+        self.lastQueueMeta = { source = "ac", reason = nil, phase = nil }
         return queue
     end
 
@@ -189,14 +189,28 @@ function Engine:ComputeQueue(iconCount)
     end
 
     -- Store metadata for display features
+    local source = "ac"
+    local reason = nil
     if firedRule then
-        self.lastQueueMeta = {
-            source = firedRule.type == "PIN" and "pin" or "prefer",
-            reason = firedRule.reason,
-        }
-    else
-        self.lastQueueMeta = { source = "ac", reason = nil }
+        source = firedRule.type == "PIN" and "pin" or "prefer"
+        reason = firedRule.reason
     end
+
+    -- Phase detection: profile-specific first, then engine-level AoE
+    local phase = nil
+    if profile.GetPhase then
+        phase = profile:GetPhase()
+    end
+    if not phase then
+        local aoeOk = self:EvalCondition({ type = "target_count", op = ">=", value = 3 })
+        if aoeOk then phase = "AoE" end
+    end
+
+    self.lastQueueMeta = {
+        source = source,
+        reason = reason,
+        phase = phase,
+    }
 
     -- Positions 2+ from GetRotationSpells()
     local rotSpells = C_AssistedCombat.GetRotationSpells()

--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -218,6 +218,24 @@ function Profile:GetDebugLines()
 end
 
 ------------------------------------------------------------------------
+-- Phase detection (for overlay display)
+------------------------------------------------------------------------
+
+function Profile:GetPhase()
+    local s = self.state
+    if GetTime() < s.witheringFireUntil then return "Burst" end
+    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3) then
+        if C_Spell and C_Spell.GetSpellCharges then
+            local ok, info = pcall(C_Spell.GetSpellCharges, 217200)
+            if ok and info and info.currentCharges and info.currentCharges > 0 then
+                return "Charge Dump"
+            end
+        end
+    end
+    return nil
+end
+
+------------------------------------------------------------------------
 -- Register
 ------------------------------------------------------------------------
 

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -132,6 +132,24 @@ function Profile:GetDebugLines()
 end
 
 ------------------------------------------------------------------------
+-- Phase detection (for overlay display)
+------------------------------------------------------------------------
+
+function Profile:GetPhase()
+    local s = self.state
+    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) < 15 then return "Burst" end
+    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3) then
+        if C_Spell and C_Spell.GetSpellCharges then
+            local ok, info = pcall(C_Spell.GetSpellCharges, 217200)
+            if ok and info and info.currentCharges and info.currentCharges > 0 then
+                return "Charge Dump"
+            end
+        end
+    end
+    return nil
+end
+
+------------------------------------------------------------------------
 -- Register
 ------------------------------------------------------------------------
 

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -90,11 +90,25 @@ local function CreateSettingsPanel()
         cooldownDesc, 0, -18, "showWhyOverlay"
     )
 
+    local phaseCheck, phaseDesc = CreateCheckbox(
+        panel,
+        "Show rotation phase",
+        "Display the current rotation phase above the overlay (Burst, AoE, Charge Dump). Hidden during normal single-target rotation.",
+        whyDesc, 0, -18, "showPhaseIndicator"
+    )
+
+    local overrideCheck, overrideDesc = CreateCheckbox(
+        panel,
+        "Show AC override indicator",
+        "Tint the primary icon border blue when HunterFlow is overriding Assisted Combat. Normal border when AC passthrough is active.",
+        phaseDesc, 0, -18, "showOverrideIndicator"
+    )
+
     local diagnosticsCheck, diagnosticsDesc = CreateCheckbox(
         panel,
         "Enable probe diagnostics",
         "Keep the heavier signal probe commands off by default. Turn this on only when you explicitly want `/hf probe ...` for API validation or debugging.",
-        whyDesc, 0, -18, "enableDiagnostics"
+        overrideDesc, 0, -18, "enableDiagnostics"
     )
 
     local unlockButton = CreateFrame("Button", nil, panel, "UIPanelButtonTemplate")
@@ -121,6 +135,8 @@ local function CreateSettingsPanel()
         castCheck.sync()
         cooldownCheck:SetChecked(HunterFlow.GetOpt("showCooldownSwipe"))
         whyCheck.sync()
+        phaseCheck.sync()
+        overrideCheck.sync()
         diagnosticsCheck.sync()
     end)
 


### PR DESCRIPTION
## Summary

Two new optional overlay features, both off by default.

**Phase Indicator (#21):**
- Shows current rotation phase above the overlay: Burst, AoE, Charge Dump
- Profiles provide `GetPhase()` from existing state (no new API calls)
- Engine adds AoE phase from `target_count >= 3`
- Gold text, hidden during normal single-target rotation

**AC Override Transparency (#22):**
- Tints primary icon border blue when HunterFlow overrides AC (PIN/PREFER)
- White border during AC passthrough
- Correct attribution: only shows override when a rule actually fired

Both use the `lastQueueMeta` infrastructure from #20.

## Test plan

- [ ] Enable phase indicator: "Burst" during Withering Fire / BW window
- [ ] Enable phase indicator: "AoE" with 3+ hostile nameplates
- [ ] Enable phase indicator: "Charge Dump" near BW CD end with charges
- [ ] Enable override indicator: blue border when BA/WA/WT rules fire
- [ ] Enable override indicator: white border during normal AC passthrough
- [ ] Toggle both off: no visual artifacts remain