### PR TITLE
fix: add issecretvalue guard to GetPhase charge check

### DIFF
--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -227,8 +227,10 @@ function Profile:GetPhase()
     if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3) then
         if C_Spell and C_Spell.GetSpellCharges then
             local ok, info = pcall(C_Spell.GetSpellCharges, 217200)
-            if ok and info and info.currentCharges and info.currentCharges > 0 then
-                return "Charge Dump"
+            if ok and info and info.currentCharges then
+                if not (issecretvalue and issecretvalue(info.currentCharges)) and info.currentCharges > 0 then
+                    return "Charge Dump"
+                end
             end
         end
     end

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -141,8 +141,10 @@ function Profile:GetPhase()
     if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3) then
         if C_Spell and C_Spell.GetSpellCharges then
             local ok, info = pcall(C_Spell.GetSpellCharges, 217200)
-            if ok and info and info.currentCharges and info.currentCharges > 0 then
-                return "Charge Dump"
+            if ok and info and info.currentCharges then
+                if not (issecretvalue and issecretvalue(info.currentCharges)) and info.currentCharges > 0 then
+                    return "Charge Dump"
+                end
             end
         end
     end


### PR DESCRIPTION
GetPhase() compared currentCharges > 0 without secret value check. Secret values produce unpredictable comparisons, causing permanent 'Charge Dump' phase display with 0 charges.