### PR TITLE
chore: prepare codebase for multi-class profiles

### DIFF
--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -53,7 +53,7 @@ local function CreateSettingsPanel()
     subtitle:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
     subtitle:SetPoint("RIGHT", panel, "RIGHT", -16, 0)
     subtitle:SetJustifyH("LEFT")
-    subtitle:SetText("Midnight-compatible hunter overlay on top of Blizzard Assisted Combat. Keep the panel lean: settings here should stay practical and low-overhead.")
+    subtitle:SetText("Midnight-compatible rotation overlay on top of Blizzard Assisted Combat. Keep the panel lean: settings here should stay practical and low-overhead.")
 
     local lockCheck, lockDesc = CreateCheckbox(
         panel,

--- a/SignalProbe.lua
+++ b/SignalProbe.lua
@@ -1,4 +1,4 @@
--- SignalProbe: in-game validation harness for shared hunter signals
+-- SignalProbe: in-game validation harness for shared signal surfaces
 -- Run /ts probe <signal> to test API surfaces before profiles depend on them.
 -- Results feed into docs/SIGNAL_VALIDATION.md classification.
 

--- a/TrueShot.toc
+++ b/TrueShot.toc
@@ -1,6 +1,6 @@
 ## Interface: 120000
 ## Title: TrueShot
-## Notes: Hunter rotation overlay for WoW Midnight. BM profiles: Dark Ranger, Pack Leader.
+## Notes: Rotation overlay for WoW Midnight. Layers class-specific priority logic on top of Blizzard Assisted Combat.
 ## Author: itsDNNS
 ## Version: 0.3.0-alpha
 ## SavedVariables: TrueShotDB

--- a/docs/PROFILE_AUTHORING.md
+++ b/docs/PROFILE_AUTHORING.md
@@ -1,6 +1,6 @@
 # Profile Authoring Guide
 
-This guide turns the current `TrueShot` framework into a repeatable authoring workflow for new hunter profiles and hero-path variants.
+This guide turns the current `TrueShot` framework into a repeatable authoring workflow for new profiles and hero-path variants.
 
 Use this together with:
 
@@ -19,7 +19,7 @@ The goal is to ship a profile that is:
 
 ## Quick Start
 
-1. Copy [`HunterProfileTemplate.lua`](templates/HunterProfileTemplate.lua).
+1. Copy [`ProfileTemplate.lua`](templates/ProfileTemplate.lua).
 2. Rename it for the target profile, for example `Profiles/MM_Sentinel.lua`.
 3. Write down the guide or priority source you are translating.
 4. Classify each desired mechanic as:
@@ -164,7 +164,7 @@ TrueShot/
 
 Authoring template:
 
-- [`HunterProfileTemplate.lua`](templates/HunterProfileTemplate.lua)
+- [`ProfileTemplate.lua`](templates/ProfileTemplate.lua)
 
 Only add a new profile to `TrueShot.toc` when the module is ready to register and be loaded by the addon.
 

--- a/docs/templates/ProfileTemplate.lua
+++ b/docs/templates/ProfileTemplate.lua
@@ -1,14 +1,18 @@
 -- TrueShot Profile Template
--- Copy this file when starting a new profile module.
--- Do not add the file to TrueShot.toc until the profile is ready to load.
+-- Copy this file when starting a new class/spec profile.
+-- Replace the example values with your class, spec, and hero path.
+-- Add the file to TrueShot.toc (after Engine.lua, before Core.lua) when ready.
+--
+-- Examples:
+--   Hunter BM Dark Ranger: specID=253, markerSpell=466930 (Black Arrow)
+--   Demon Hunter Havoc:    specID=577, markerSpell=nil (or hero-specific)
 
 local Engine = TrueShot.Engine
 
 local Profile = {
-    id = "Hunter.MM.ExampleHero",
-    class = "HUNTER",
-    specID = 254,
-    hero = "ExampleHero",
+    id = "Class.Spec.HeroPath",  -- e.g. "DemonHunter.Havoc.AldrachiReaver"
+    specID = 0,                   -- WoW spec ID (GetSpecializationInfo)
+    markerSpell = nil,            -- hero-path exclusive spell for auto-detection (optional)
 
     -- Keep state small, explicit, and tied to observable signals.
     state = {
@@ -18,11 +22,13 @@ local Profile = {
     },
 
     rules = {
-        -- Example:
+        -- Example rules (uncomment and adapt):
+        -- { type = "BLACKLIST", spellID = 0 },  -- filter utility spells
         -- {
         --     type = "PREFER",
         --     spellID = 0,
-        --     condition = { type = "tracked_spell_ready" },
+        --     reason = "Burst Window",  -- shown in Why overlay
+        --     condition = { type = "in_burst_window" },
         -- },
     },
 }


### PR DESCRIPTION
Removes hunter-specific branding from engine/core/display/settings. Renames profile template to be class-generic with DH Havoc example. No logic changes.