### PR TITLE
fix: persistent /ts hide and stale phase after combat

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -21,6 +21,7 @@ local DEFAULTS = {
     showWhyOverlay = false,
     showPhaseIndicator = false,
     showOverrideIndicator = false,
+    hidden = false,
 }
 
 local optionCallbacks = {}
@@ -80,7 +81,9 @@ local function TryActivate()
         return false
     end
 
-    Display:Enable()
+    if not TrueShot.GetOpt("hidden") then
+        Display:Enable()
+    end
     return true
 end
 
@@ -127,7 +130,7 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
 
     elseif event == "PLAYER_REGEN_DISABLED" then
         Engine.combatStartTime = GetTime()
-        if Engine.activeProfile and not Display.container:IsShown() then
+        if Engine.activeProfile and not Display.container:IsShown() and not TrueShot.GetOpt("hidden") then
             Display:Enable()
         end
 
@@ -196,10 +199,12 @@ SlashCmdList["TRUESHOT"] = function(msg)
         end
 
     elseif msg == "hide" then
+        TrueShot.SetOpt("hidden", true)
         Display:Disable()
         print("|cff00ff00[TS]|r Hidden. /ts show to restore.")
 
     elseif msg == "show" then
+        TrueShot.SetOpt("hidden", false)
         Display:Enable()
 
     elseif msg == "options" or msg == "config" then

--- a/Display.lua
+++ b/Display.lua
@@ -46,6 +46,7 @@ content:SetPoint("TOPLEFT", container, "TOPLEFT", CONTAINER_PADDING_X, -CONTAINE
 content:SetPoint("BOTTOMRIGHT", container, "BOTTOMRIGHT", -CONTAINER_PADDING_X, CONTAINER_PADDING_Y)
 
 Display.container = container
+container:Hide()
 
 container:SetClipsChildren(false)
 

--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -157,6 +157,8 @@ end
 
 function Profile:OnCombatEnd()
     self.state.lastCastWasKC = false
+    self.state.witheringFireUntil = 0
+    self.state.lastBWCast = 0
 end
 
 ------------------------------------------------------------------------

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -92,6 +92,7 @@ end
 
 function Profile:OnCombatEnd()
     self.state.lastCastWasKC = false
+    self.state.lastBWCast = 0
 end
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Codex CLI review findings, verified clean after fixes. Container starts hidden, /ts hide persists across combat/reload, OnCombatEnd clears BW/WF timers.