### PR TITLE
chore: remove legacy HunterFlowDB migration

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -10,14 +10,6 @@ TrueShot = TrueShot or {}
 
 TrueShotDB = TrueShotDB or {}
 
--- One-time migration from legacy HunterFlowDB
-if HunterFlowDB and next(HunterFlowDB) and not next(TrueShotDB) then
-    for k, v in pairs(HunterFlowDB) do
-        TrueShotDB[k] = v
-    end
-    HunterFlowDB = nil
-end
-
 local DEFAULTS = {
     iconCount = 2,
     iconSize = 40,

--- a/TrueShot.toc
+++ b/TrueShot.toc
@@ -3,7 +3,7 @@
 ## Notes: Rotation overlay for WoW Midnight. Layers class-specific priority logic on top of Blizzard Assisted Combat.
 ## Author: itsDNNS
 ## Version: 0.3.0-alpha
-## SavedVariables: TrueShotDB, HunterFlowDB
+## SavedVariables: TrueShotDB
 
 Engine.lua
 Profiles/BM_DarkRanger.lua


### PR DESCRIPTION
Single-user addon, no migration needed.