### PR TITLE
fix: charge dump no longer displaces Black Arrow before first BW

### DIFF
--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -195,7 +195,7 @@ function Profile:EvalCondition(cond)
         return (GetTime() - s.lastBWCast) < BW_COOLDOWN_ESTIMATE
 
     elseif cond.type == "bw_nearly_ready" then
-        if s.lastBWCast == 0 then return true end
+        if s.lastBWCast == 0 then return false end
         return (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3)
     end
 

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -110,7 +110,7 @@ function Profile:EvalCondition(cond)
         return (GetTime() - s.lastBWCast) < BW_COOLDOWN_ESTIMATE
 
     elseif cond.type == "bw_nearly_ready" then
-        if s.lastBWCast == 0 then return true end
+        if s.lastBWCast == 0 then return false end
         return (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3)
     end
 


### PR DESCRIPTION
bw_nearly_ready returned true before first BW cast, permanently firing charge dump over BA. Now returns false until BW used. Codex reviewed.