### PR TITLE
fix: use real cooldown data for BW blacklist instead of timer estimate

### DIFF
--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -4,7 +4,20 @@
 local Engine = TrueShot.Engine
 
 local BA_COOLDOWN = 10
-local BW_COOLDOWN_ESTIMATE = 29
+local BW_SPELL_ID = 19574
+local C_Spell_GetSpellCooldown = C_Spell and C_Spell.GetSpellCooldown
+
+local function IsBWOnCooldown()
+    if C_Spell_GetSpellCooldown then
+        local ok, cd = pcall(C_Spell_GetSpellCooldown, BW_SPELL_ID)
+        if ok and cd then
+            local duration = cd.duration or 0
+            if issecretvalue and issecretvalue(duration) then return nil end
+            return duration > 1.5  -- ignore GCD-only cooldowns
+        end
+    end
+    return nil  -- signal unavailable, caller uses fallback
+end
 
 ------------------------------------------------------------------------
 -- Profile definition
@@ -191,12 +204,17 @@ function Profile:EvalCondition(cond)
         return s.lastCastWasKC
 
     elseif cond.type == "bw_on_cd" then
+        local cdCheck = IsBWOnCooldown()
+        if cdCheck ~= nil then return cdCheck end
         if s.lastBWCast == 0 then return false end
-        return (GetTime() - s.lastBWCast) < BW_COOLDOWN_ESTIMATE
+        return (GetTime() - s.lastBWCast) < 60  -- conservative fallback
 
     elseif cond.type == "bw_nearly_ready" then
+        local cdCheck = IsBWOnCooldown()
+        if cdCheck == true then return false end   -- still on CD
+        if cdCheck == false then return true end   -- CD done, ready to use
         if s.lastBWCast == 0 then return false end
-        return (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3)
+        return (GetTime() - s.lastBWCast) >= 55   -- conservative fallback
     end
 
     return nil -- not handled by this profile
@@ -226,7 +244,8 @@ end
 function Profile:GetPhase()
     local s = self.state
     if GetTime() < s.witheringFireUntil then return "Burst" end
-    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3) then
+    local bwOnCD = IsBWOnCooldown()
+    if bwOnCD == false then
         if C_Spell and C_Spell.GetSpellCharges then
             local ok, info = pcall(C_Spell.GetSpellCharges, 217200)
             if ok and info and info.currentCharges then

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -3,7 +3,20 @@
 
 local Engine = TrueShot.Engine
 
-local BW_COOLDOWN_ESTIMATE = 29
+local BW_SPELL_ID = 19574
+local C_Spell_GetSpellCooldown = C_Spell and C_Spell.GetSpellCooldown
+
+local function IsBWOnCooldown()
+    if C_Spell_GetSpellCooldown then
+        local ok, cd = pcall(C_Spell_GetSpellCooldown, BW_SPELL_ID)
+        if ok and cd then
+            local duration = cd.duration or 0
+            if issecretvalue and issecretvalue(duration) then return nil end
+            return duration > 1.5
+        end
+    end
+    return nil
+end
 
 ------------------------------------------------------------------------
 -- Profile definition
@@ -106,12 +119,17 @@ function Profile:EvalCondition(cond)
         return s.lastCastWasKC
 
     elseif cond.type == "bw_on_cd" then
+        local cdCheck = IsBWOnCooldown()
+        if cdCheck ~= nil then return cdCheck end
         if s.lastBWCast == 0 then return false end
-        return (GetTime() - s.lastBWCast) < BW_COOLDOWN_ESTIMATE
+        return (GetTime() - s.lastBWCast) < 60
 
     elseif cond.type == "bw_nearly_ready" then
+        local cdCheck = IsBWOnCooldown()
+        if cdCheck == true then return false end
+        if cdCheck == false then return true end
         if s.lastBWCast == 0 then return false end
-        return (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3)
+        return (GetTime() - s.lastBWCast) >= 55
     end
 
     return nil -- not handled by this profile
@@ -126,7 +144,7 @@ function Profile:GetDebugLines()
     local bwElapsed = s.lastBWCast > 0 and (GetTime() - s.lastBWCast) or 0
     return {
         "  BW CD: " .. (s.lastBWCast > 0
-            and string.format("%.1fs elapsed (est ~%ds)", bwElapsed, BW_COOLDOWN_ESTIMATE)
+            and string.format("%.1fs elapsed (est ~%ds)", bwElapsed, 60)
             or "not cast yet"),
         "  Last cast was KC: " .. tostring(s.lastCastWasKC),
     }
@@ -138,8 +156,9 @@ end
 
 function Profile:GetPhase()
     local s = self.state
-    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) < 15 then return "Burst" end
-    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN_ESTIMATE - 3) then
+    local bwOnCD = IsBWOnCooldown()
+    if bwOnCD == true and s.lastBWCast > 0 and (GetTime() - s.lastBWCast) < 15 then return "Burst" end
+    if bwOnCD == false then
         if C_Spell and C_Spell.GetSpellCharges then
             local ok, info = pcall(C_Spell.GetSpellCharges, 217200)
             if ok and info and info.currentCharges then


### PR DESCRIPTION
BW_COOLDOWN_ESTIMATE (29s) was far too short for actual BW CD (90s base, variable). Now uses C_Spell.GetSpellCooldown with secret guard and conservative timer fallback. 3 Codex review rounds.