### PR TITLE
fix: BW timer persists across combat boundaries

### DIFF
--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -113,7 +113,6 @@ local Profile = {
 function Profile:ResetState()
     self.state.blackArrowReady = true
     self.state.lastBlackArrowCast = 0
-    self.state.lastBWCast = 0
     self.state.witheringFireUntil = 0
     self.state.wailingArrowAvailable = false
     self.state.lastCastWasKC = false
@@ -158,7 +157,6 @@ end
 function Profile:OnCombatEnd()
     self.state.lastCastWasKC = false
     self.state.witheringFireUntil = 0
-    self.state.lastBWCast = 0
 end
 
 ------------------------------------------------------------------------
@@ -224,6 +222,7 @@ end
 ------------------------------------------------------------------------
 
 function Profile:GetPhase()
+    if not UnitAffectingCombat("player") then return nil end
     local s = self.state
     if GetTime() < s.witheringFireUntil then return "Burst" end
     if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN - 3) then

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -71,7 +71,6 @@ local Profile = {
 ------------------------------------------------------------------------
 
 function Profile:ResetState()
-    self.state.lastBWCast = 0
     self.state.lastCastWasKC = false
 end
 
@@ -92,7 +91,6 @@ end
 
 function Profile:OnCombatEnd()
     self.state.lastCastWasKC = false
-    self.state.lastBWCast = 0
 end
 
 ------------------------------------------------------------------------
@@ -137,6 +135,7 @@ end
 ------------------------------------------------------------------------
 
 function Profile:GetPhase()
+    if not UnitAffectingCombat("player") then return nil end
     local s = self.state
     if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) < 15 then return "Burst" end
     if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) >= (BW_COOLDOWN - 3) then


### PR DESCRIPTION
BW CD timer no longer resets on combat end. GetPhase gated on combat state. Codex clean.