### PR TITLE
perf: nameplate cache, keybind cache, module-level IsBlocked

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -78,10 +78,14 @@ local function ClearCooldown(icon)
     icon.cooldown:Hide()
 end
 
-local function GetKeybindForSpell(spellID)
+local keybindCache = {}
+local keybindCacheDirty = true
+
+local function RebuildKeybindCache()
+    wipe(keybindCache)
     for slot = 1, 120 do
         local actionType, id = GetActionInfo(slot)
-        if actionType == "spell" and id == spellID then
+        if actionType == "spell" and id then
             local key = GetBindingKey("ACTIONBUTTON" .. ((slot - 1) % 12 + 1))
             if not key then
                 local bar = math.ceil(slot / 12)
@@ -92,10 +96,23 @@ local function GetKeybindForSpell(spellID)
                     key = GetBindingKey("MULTIACTIONBAR" .. (bar - 1) .. "BUTTON" .. btn)
                 end
             end
-            if key then return key end
+            if key and not keybindCache[id] then
+                keybindCache[id] = key
+            end
         end
     end
-    return nil
+    keybindCacheDirty = false
+end
+
+local keybindFrame = CreateFrame("Frame")
+keybindFrame:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
+keybindFrame:RegisterEvent("UPDATE_BINDINGS")
+keybindFrame:RegisterEvent("SPELLS_CHANGED")
+keybindFrame:SetScript("OnEvent", function() keybindCacheDirty = true end)
+
+local function GetKeybindForSpell(spellID)
+    if keybindCacheDirty then RebuildKeybindCache() end
+    return keybindCache[spellID]
 end
 
 local function CreateIcon(index)

--- a/Engine.lua
+++ b/Engine.lua
@@ -15,6 +15,34 @@ local function IsSecret(val)
     return issecretvalue and issecretvalue(val) or false
 end
 
+-- Per-tick hostile nameplate cache (invalidated each ComputeQueue call)
+local _hostileCount = 0
+local _hostileCountTick = 0
+
+local function GetHostileCount()
+    local now = GetTime()
+    if _hostileCountTick == now then return _hostileCount end
+    _hostileCountTick = now
+    if not C_NamePlate or not C_NamePlate.GetNamePlates then
+        _hostileCount = 0
+        return 0
+    end
+    local ok, plates = pcall(C_NamePlate.GetNamePlates)
+    if not ok or not plates or IsSecret(plates) then
+        _hostileCount = 0
+        return 0
+    end
+    local count = 0
+    for _, plate in ipairs(plates) do
+        local unit = plate.namePlateUnitToken
+        if unit and UnitExists(unit) and UnitCanAttack("player", unit) then
+            count = count + 1
+        end
+    end
+    _hostileCount = count
+    return count
+end
+
 ------------------------------------------------------------------------
 -- Condition evaluator (generic conditions only)
 ------------------------------------------------------------------------
@@ -40,17 +68,7 @@ function Engine:EvalCondition(cond)
         return false
 
     elseif cond.type == "target_count" then
-        if not C_NamePlate or not C_NamePlate.GetNamePlates then return false end
-        local ok, plates = pcall(C_NamePlate.GetNamePlates)
-        if not ok or not plates then return false end
-        if IsSecret(plates) then return false end
-        local count = 0
-        for _, plate in ipairs(plates) do
-            local unit = plate.namePlateUnitToken
-            if unit and UnitExists(unit) and UnitCanAttack("player", unit) then
-                count = count + 1
-            end
-        end
+        local count = GetHostileCount()
         if cond.op == ">=" then return count >= cond.value end
         if cond.op == ">" then return count > cond.value end
         return false
@@ -133,6 +151,10 @@ local _condBlacklist = {}
 local _seen = {}
 local _aoeCondition = { type = "target_count", op = ">=", value = 3 }
 
+local function IsBlocked(spellID)
+    return blacklistedSpells[spellID] or _condBlacklist[spellID]
+end
+
 function Engine:ComputeQueue(iconCount)
     wipe(_queue)
     local queue = _queue
@@ -162,9 +184,7 @@ function Engine:ComputeQueue(iconCount)
         end
     end
 
-    local function IsBlocked(spellID)
-        return blacklistedSpells[spellID] or condBlacklist[spellID]
-    end
+    -- IsBlocked uses module-level tables (blacklistedSpells + _condBlacklist)
 
     -- PIN rules (highest priority, first match wins)
     local pinnedSpell = nil


### PR DESCRIPTION
Three perf optimizations reducing per-tick work. Codex clean, no functional changes.