### PR TITLE
Fix Survival queue utility filtering and Hatchet Toss melee gating

### DIFF
--- a/Engine.lua
+++ b/Engine.lua
@@ -153,9 +153,54 @@ local _queue = {}
 local _condBlacklist = {}
 local _seen = {}
 local _aoeCondition = { type = "target_count", op = ">=", value = 3 }
+local SV_SPEC_ID = 255
+local SV_HATCHET_TOSS_NAME = "Hatchet Toss"
+local SV_MELEE_RANGE_CHECK_IDS = {
+    186270, -- Raptor Strike
+    259387, -- Mongoose Bite
+}
 
 local function IsBlocked(spellID)
     return blacklistedSpells[spellID] or _condBlacklist[spellID]
+end
+
+local function IsSpellName(spellID, expectedName)
+    if not spellID or not expectedName or not C_Spell or not C_Spell.GetSpellName then
+        return false
+    end
+    local ok, spellName = pcall(C_Spell.GetSpellName, spellID)
+    return ok and spellName == expectedName
+end
+
+local function IsOutOfMeleeRange()
+    if not UnitExists("target") or not UnitCanAttack("player", "target") then
+        return false
+    end
+    if not C_Spell or not C_Spell.IsSpellInRange then return false end
+
+    local hadReadableProbe = false
+    for _, spellID in ipairs(SV_MELEE_RANGE_CHECK_IDS) do
+        local ok, inRange = pcall(C_Spell.IsSpellInRange, spellID, "target")
+        if ok and inRange ~= nil and not IsSecret(inRange) then
+            hadReadableProbe = true
+            if inRange == true then
+                return false
+            end
+        end
+    end
+
+    return hadReadableProbe
+end
+
+function Engine:IsSuppressedBySpecRules(spellID)
+    local profile = self.activeProfile
+    if not profile or profile.specID ~= SV_SPEC_ID then return false end
+
+    if IsSpellName(spellID, SV_HATCHET_TOSS_NAME) then
+        return not IsOutOfMeleeRange()
+    end
+
+    return false
 end
 
 function Engine:ComputeQueue(iconCount)
@@ -219,8 +264,10 @@ function Engine:ComputeQueue(iconCount)
     -- Position 1
     if baseSpell and IsBlocked(baseSpell) then baseSpell = nil end
     local pos1 = pinnedSpell or preferredSpell or baseSpell
-    if pos1 and not IsBlocked(pos1) then
+    local queuedPos1 = nil
+    if pos1 and not IsBlocked(pos1) and not self:IsSuppressedBySpecRules(pos1) then
         queue[#queue + 1] = pos1
+        queuedPos1 = pos1
     end
 
     -- Store metadata for display features
@@ -249,7 +296,7 @@ function Engine:ComputeQueue(iconCount)
     if rotSpells then
         wipe(_seen)
         local seen = _seen
-        if pos1 then seen[pos1] = true end
+        if queuedPos1 then seen[queuedPos1] = true end
 
         for _, entry in ipairs(rotSpells) do
             if #queue >= iconCount then break end
@@ -262,6 +309,7 @@ function Engine:ComputeQueue(iconCount)
             if spellID
                 and not seen[spellID]
                 and not IsBlocked(spellID)
+                and not self:IsSuppressedBySpecRules(spellID)
                 and self:IsSpellCastable(spellID)
             then
                 queue[#queue + 1] = spellID

--- a/Profiles/SV_PackLeader.lua
+++ b/Profiles/SV_PackLeader.lua
@@ -19,6 +19,8 @@ local SPELLS = {
     FlamefangPitch = 1251592,
     RaptorStrike   = 186270,
     Harpoon        = 190925,
+    CallPet1       = 883,
+    RevivePet      = 982,
 }
 
 ------------------------------------------------------------------------
@@ -41,6 +43,8 @@ local Profile = {
     rules = {
         -- Filter utility spells
         { type = "BLACKLIST", spellID = SPELLS.Harpoon },
+        { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
+        { type = "BLACKLIST", spellID = SPELLS.RevivePet },
 
         -- Stampede: first KC after Takedown triggers Stampede
         {

--- a/Profiles/SV_Sentinel.lua
+++ b/Profiles/SV_Sentinel.lua
@@ -18,6 +18,8 @@ local SPELLS = {
     MoonlightChakram = 1264902,
     FlamefangPitch   = 1251592,
     Harpoon          = 190925,
+    CallPet1         = 883,
+    RevivePet        = 982,
 }
 
 ------------------------------------------------------------------------
@@ -39,6 +41,8 @@ local Profile = {
     rules = {
         -- Filter utility spells
         { type = "BLACKLIST", spellID = SPELLS.Harpoon },
+        { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
+        { type = "BLACKLIST", spellID = SPELLS.RevivePet },
 
         -- Prevent capping WFB charges while fishing Sentinel's Mark procs
         {


### PR DESCRIPTION
# Survival Queue Fixes (2026-04-05)

## Commit

- **Hash:** `b81eea0`
- **Branch:** `main`
- **Pushed to:** `origin/main`
- **Message:** `Fix Survival queue utility filtering and Hatchet Toss melee gating`

## What Was Fixed

This update addressed two Survival queue problems:

1. **Pet utility spells showing in rotation queue**
   - `Call Pet 1` (883) and `Revive Pet` (982) were being suggested in Survival queue output.
   - These are now blacklisted for Survival profiles so they do not appear as normal rotation recommendations.

2. **Hatchet Toss getting stuck in queue while in melee**
   - Hatchet Toss was sometimes over-recommended.
   - Survival-specific gating was added so Hatchet Toss is suppressed unless the target is actually out of melee range.

## Files Updated

- `Engine.lua`
- `Profiles/SV_PackLeader.lua`
- `Profiles/SV_Sentinel.lua`

## Behavior After Fix

- Survival queue no longer recommends pet summon/revive utility spells.
- Hatchet Toss is no longer a general fallback in melee.
- Hatchet Toss is only eligible when out of melee range.
