### PR TITLE
Add XY position controls in settings

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -756,12 +756,13 @@ function Display:SetPositionOffsets(xOfs, yOfs)
         return false
     end
 
-    local point, _, relativePoint = container:GetPoint(1)
+    local point, relativeTo, relativePoint = container:GetPoint(1)
     point = point or "CENTER"
     relativePoint = relativePoint or point
+    relativeTo = relativeTo or UIParent
 
     container:ClearAllPoints()
-    container:SetPoint(point, UIParent, relativePoint, xOfs, yOfs)
+    container:SetPoint(point, relativeTo, relativePoint, xOfs, yOfs)
 
     TrueShot.SetOpt("posPoint", point)
     TrueShot.SetOpt("posRelPoint", relativePoint)

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -266,16 +266,25 @@ local function CreateSettingsPanel()
         end
     end
 
+    local applyingFromEnter = false
     xEdit:SetScript("OnEnterPressed", function(self)
+        applyingFromEnter = true
         ApplyPositionFromInputs()
         self:ClearFocus()
+        applyingFromEnter = false
     end)
     yEdit:SetScript("OnEnterPressed", function(self)
+        applyingFromEnter = true
         ApplyPositionFromInputs()
         self:ClearFocus()
+        applyingFromEnter = false
     end)
-    xEdit:SetScript("OnEditFocusLost", ApplyPositionFromInputs)
-    yEdit:SetScript("OnEditFocusLost", ApplyPositionFromInputs)
+    xEdit:SetScript("OnEditFocusLost", function()
+        if not applyingFromEnter then ApplyPositionFromInputs() end
+    end)
+    yEdit:SetScript("OnEditFocusLost", function()
+        if not applyingFromEnter then ApplyPositionFromInputs() end
+    end)
     applyCoordsButton:SetScript("OnClick", ApplyPositionFromInputs)
 
     -- Orientation
@@ -376,6 +385,7 @@ local function CreateSettingsPanel()
     end)
 
     panel:SetScript("OnUpdate", function(_, elapsed)
+        if not panel:IsShown() then return end
         panel._coordsElapsed = (panel._coordsElapsed or 0) + elapsed
         if panel._coordsElapsed < 0.2 then return end
         panel._coordsElapsed = 0


### PR DESCRIPTION
I think I cleaned this up to not have a regression on the other Engine.lua items.