### PR TITLE
Profile Import/Export (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   - Strict security: no code execution, whitelist-based parsing
   - Export/Import buttons in the Rule Builder
   - Profiles are tied to their target spec and only activate on the matching character
+- **Profile Library**: Multiple custom profiles per spec with instant switching
+  - Import adds to library instead of overwriting
+  - Profile selector dropdown in Rule Builder when 2+ profiles exist
+  - Delete individual profiles from the library
+  - Auto-migration from previous single-profile storage format
 
 ## v0.19.0 - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.20.0 - 2026-04-09
+
+### Added
+- **Profile Import/Export** (`/ts export`, `/ts import`): Share custom profiles as copy-paste strings
+  - Zero external dependencies (custom serializer + Base64 codec)
+  - 4-phase validation: format, schema, semantic, warnings
+  - Preview before import with validation results
+  - Strict security: no code execution, whitelist-based parsing
+  - Export/Import buttons in the Rule Builder
+  - Profiles are tied to their target spec and only activate on the matching character
+
 ## v0.19.0 - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
   - Profile selector dropdown in Rule Builder when 2+ profiles exist
   - Delete individual profiles from the library
   - Auto-migration from previous single-profile storage format
+- **Profile Browser** (`/ts profiles`): Hierarchical view of all registered profiles
+  - Collapsible tree: Class > Spec > Hero Talent
+  - Shows all profiles across all classes, not just the current spec
+  - View button opens the Rule Builder for the selected profile
+  - Export button for profiles with custom data
+  - Active/customized/variant indicators per profile
+  - Accessible from Rule Builder ("Browse All" button) or slash command
 
 ## v0.19.0 - 2026-04-09
 

--- a/Core.lua
+++ b/Core.lua
@@ -354,7 +354,14 @@ SlashCmdList["TRUESHOT"] = function(msg)
             print("|cffff0000[TS]|r Rule Builder not loaded.")
         end
 
-    elseif msg == "profiles" or msg == "browse" then
+    elseif msg == "profiles" then
+        if TrueShot.RuleBuilder and TrueShot.RuleBuilder.Toggle then
+            TrueShot.RuleBuilder:Toggle()
+        else
+            print("|cffff0000[TS]|r Rule Builder not loaded.")
+        end
+
+    elseif msg == "browse" then
         if TrueShot.ProfileIO and TrueShot.ProfileIO.ToggleBrowser then
             TrueShot.ProfileIO:ToggleBrowser()
         else
@@ -372,7 +379,8 @@ SlashCmdList["TRUESHOT"] = function(msg)
         print("  /ts debug   - Print queue and profile state")
         print("  /ts score   - Show recent alignment scores")
         print("  /ts rules   - Open the Visual Rule Builder")
-        print("  /ts profiles - Browse all profiles (Class > Spec > Hero Talent)")
+        print("  /ts profiles - Open the Visual Rule Builder (alias for /ts rules)")
+        print("  /ts browse  - Browse all profiles (Class > Spec > Hero Talent)")
         print("  /ts export  - Export custom profile as shareable string")
         print("  /ts import  - Import a profile from a shared string")
         print("  /ts diagnostics on|off - Enable or disable probe diagnostics")

--- a/Core.lua
+++ b/Core.lua
@@ -333,6 +333,20 @@ SlashCmdList["TRUESHOT"] = function(msg)
             print("|cff00ff00[TS]|r Scorecard not loaded.")
         end
 
+    elseif msg == "export" then
+        if TrueShot.ProfileIO and TrueShot.ProfileIO.ShowExport then
+            TrueShot.ProfileIO:ShowExport()
+        else
+            print("|cffff0000[TS]|r ProfileIO not loaded.")
+        end
+
+    elseif msg == "import" then
+        if TrueShot.ProfileIO and TrueShot.ProfileIO.ShowImport then
+            TrueShot.ProfileIO:ShowImport()
+        else
+            print("|cffff0000[TS]|r ProfileIO not loaded.")
+        end
+
     elseif msg == "rules" then
         if TrueShot.RuleBuilder and TrueShot.RuleBuilder.Toggle then
             TrueShot.RuleBuilder:Toggle()
@@ -351,6 +365,8 @@ SlashCmdList["TRUESHOT"] = function(msg)
         print("  /ts debug   - Print queue and profile state")
         print("  /ts score   - Show recent alignment scores")
         print("  /ts rules   - Open the Visual Rule Builder")
+        print("  /ts export  - Export custom profile as shareable string")
+        print("  /ts import  - Import a profile from a shared string")
         print("  /ts diagnostics on|off - Enable or disable probe diagnostics")
         print("  /ts probe   - Signal validation probes (only when diagnostics are enabled)")
 

--- a/Core.lua
+++ b/Core.lua
@@ -354,6 +354,13 @@ SlashCmdList["TRUESHOT"] = function(msg)
             print("|cffff0000[TS]|r Rule Builder not loaded.")
         end
 
+    elseif msg == "profiles" or msg == "browse" then
+        if TrueShot.ProfileIO and TrueShot.ProfileIO.ToggleBrowser then
+            TrueShot.ProfileIO:ToggleBrowser()
+        else
+            print("|cffff0000[TS]|r ProfileIO not loaded.")
+        end
+
     elseif msg == "help" then
         print("|cff00ff00[TrueShot]|r Commands:")
         print("  /ts lock    - Lock frame (click-through)")
@@ -365,6 +372,7 @@ SlashCmdList["TRUESHOT"] = function(msg)
         print("  /ts debug   - Print queue and profile state")
         print("  /ts score   - Show recent alignment scores")
         print("  /ts rules   - Open the Visual Rule Builder")
+        print("  /ts profiles - Browse all profiles (Class > Spec > Hero Talent)")
         print("  /ts export  - Export custom profile as shareable string")
         print("  /ts import  - Import a profile from a shared string")
         print("  /ts diagnostics on|off - Enable or disable probe diagnostics")

--- a/CustomProfile.lua
+++ b/CustomProfile.lua
@@ -177,6 +177,15 @@ function CustomProfile.AddToLibrary(profileId, data)
         }
         return 1
     end
+    -- Check for existing profile with same name: overwrite instead of duplicate
+    if data.name then
+        for i, existing in ipairs(library.profiles) do
+            if existing.name == data.name then
+                library.profiles[i] = data
+                return i
+            end
+        end
+    end
     library.profiles[#library.profiles + 1] = data
     return #library.profiles
 end

--- a/CustomProfile.lua
+++ b/CustomProfile.lua
@@ -85,26 +85,68 @@ local function DeepCopy(orig)
     return copy
 end
 
+local function EnsureLibraryFormat(profileId)
+    if not TrueShotDB.customProfiles then return end
+    local stored = TrueShotDB.customProfiles[profileId]
+    if not stored then return end
+    -- Already in library format
+    if stored.profiles and stored.activeIndex then return end
+    -- Old format: wrap in library
+    stored.name = stored.name or "Custom"
+    TrueShotDB.customProfiles[profileId] = {
+        activeIndex = 1,
+        profiles = { stored },
+    }
+end
+
 function CustomProfile.GetCustomData(profileId)
     if not TrueShotDB.customProfiles then return nil end
-    return TrueShotDB.customProfiles[profileId]
+    EnsureLibraryFormat(profileId)
+    local library = TrueShotDB.customProfiles[profileId]
+    if not library or not library.profiles then return nil end
+    local idx = library.activeIndex or 1
+    return library.profiles[idx]
 end
 
 function CustomProfile.HasCustomData(profileId)
-    return CustomProfile.GetCustomData(profileId) ~= nil
+    if not TrueShotDB.customProfiles then return false end
+    EnsureLibraryFormat(profileId)
+    local library = TrueShotDB.customProfiles[profileId]
+    return library and library.profiles and #library.profiles > 0
 end
 
 function CustomProfile.SaveCustomData(profileId, data)
     TrueShotDB.customProfiles = TrueShotDB.customProfiles or {}
+    EnsureLibraryFormat(profileId)
     data.schemaVersion = SCHEMA_VERSION
-    TrueShotDB.customProfiles[profileId] = data
+    local library = TrueShotDB.customProfiles[profileId]
+    if library and library.profiles then
+        local idx = library.activeIndex or 1
+        library.profiles[idx] = data
+    else
+        data.name = data.name or "Custom"
+        TrueShotDB.customProfiles[profileId] = {
+            activeIndex = 1,
+            profiles = { data },
+        }
+    end
 end
 
 function CustomProfile.DeleteCustomData(profileId)
-    if TrueShotDB.customProfiles then
+    if not TrueShotDB.customProfiles then return end
+    EnsureLibraryFormat(profileId)
+    local library = TrueShotDB.customProfiles[profileId]
+    if library and library.profiles then
+        local idx = library.activeIndex or 1
+        table.remove(library.profiles, idx)
+        if #library.profiles == 0 then
+            TrueShotDB.customProfiles[profileId] = nil
+        else
+            library.activeIndex = math.min(idx, #library.profiles)
+        end
+    else
         TrueShotDB.customProfiles[profileId] = nil
     end
-    -- Clear custom condition schemas for this profile
     CustomProfile.ClearCustomConditions(profileId)
 end
 
@@ -118,12 +160,84 @@ function CustomProfile.ClearCustomConditions(profileId)
 end
 
 ------------------------------------------------------------------------
+-- Profile Library API
+------------------------------------------------------------------------
+
+function CustomProfile.GetProfileLibrary(profileId)
+    if not TrueShotDB.customProfiles then return nil end
+    EnsureLibraryFormat(profileId)
+    return TrueShotDB.customProfiles[profileId]
+end
+
+function CustomProfile.GetActiveIndex(profileId)
+    local library = CustomProfile.GetProfileLibrary(profileId)
+    if not library then return nil end
+    return library.activeIndex or 1
+end
+
+function CustomProfile.SetActiveIndex(profileId, index)
+    local library = CustomProfile.GetProfileLibrary(profileId)
+    if not library or not library.profiles then return false end
+    if index < 1 or index > #library.profiles then return false end
+    library.activeIndex = index
+    CustomProfile.InvalidateWrapper(profileId)
+    return true
+end
+
+function CustomProfile.AddToLibrary(profileId, data)
+    TrueShotDB.customProfiles = TrueShotDB.customProfiles or {}
+    EnsureLibraryFormat(profileId)
+    data.schemaVersion = SCHEMA_VERSION
+    data.name = data.name or ("Import " .. date("%Y-%m-%d %H:%M"))
+    local library = TrueShotDB.customProfiles[profileId]
+    if not library then
+        TrueShotDB.customProfiles[profileId] = {
+            activeIndex = 1,
+            profiles = { data },
+        }
+        return 1
+    end
+    library.profiles[#library.profiles + 1] = data
+    return #library.profiles
+end
+
+function CustomProfile.DeleteFromLibrary(profileId, index)
+    local library = CustomProfile.GetProfileLibrary(profileId)
+    if not library or not library.profiles then return false end
+    if index < 1 or index > #library.profiles then return false end
+    table.remove(library.profiles, index)
+    if #library.profiles == 0 then
+        TrueShotDB.customProfiles[profileId] = nil
+        CustomProfile.ClearCustomConditions(profileId)
+        return true
+    end
+    if library.activeIndex >= index then
+        library.activeIndex = math.max(1, library.activeIndex - 1)
+    end
+    return true
+end
+
+function CustomProfile.RenameInLibrary(profileId, index, newName)
+    local library = CustomProfile.GetProfileLibrary(profileId)
+    if not library or not library.profiles or not library.profiles[index] then return false end
+    library.profiles[index].name = newName
+    return true
+end
+
+function CustomProfile.GetLibraryCount(profileId)
+    local library = CustomProfile.GetProfileLibrary(profileId)
+    if not library or not library.profiles then return 0 end
+    return #library.profiles
+end
+
+------------------------------------------------------------------------
 -- Fork built-in profile into editable custom data
 ------------------------------------------------------------------------
 
 function CustomProfile.ForkProfile(baseProfile)
     local data = {
         schemaVersion = SCHEMA_VERSION,
+        name = "Custom",
         baseProfileId = baseProfile.id,
         baseProfileVersion = baseProfile.version or 0,
         rules = DeepCopy(baseProfile.rules),

--- a/CustomProfile.lua
+++ b/CustomProfile.lua
@@ -25,9 +25,6 @@ function CustomProfile.RegisterConditionSchema(source, schemas)
     end
 end
 
-function CustomProfile.GetConditionSchema(conditionId)
-    return _conditionSchemas[conditionId]
-end
 
 function CustomProfile.GetAllConditionSchemas()
     return _conditionSchemas
@@ -132,23 +129,6 @@ function CustomProfile.SaveCustomData(profileId, data)
     end
 end
 
-function CustomProfile.DeleteCustomData(profileId)
-    if not TrueShotDB.customProfiles then return end
-    EnsureLibraryFormat(profileId)
-    local library = TrueShotDB.customProfiles[profileId]
-    if library and library.profiles then
-        local idx = library.activeIndex or 1
-        table.remove(library.profiles, idx)
-        if #library.profiles == 0 then
-            TrueShotDB.customProfiles[profileId] = nil
-        else
-            library.activeIndex = math.min(idx, #library.profiles)
-        end
-    else
-        TrueShotDB.customProfiles[profileId] = nil
-    end
-    CustomProfile.ClearCustomConditions(profileId)
-end
 
 function CustomProfile.ClearCustomConditions(profileId)
     local source = profileId .. "_custom"
@@ -217,12 +197,6 @@ function CustomProfile.DeleteFromLibrary(profileId, index)
     return true
 end
 
-function CustomProfile.RenameInLibrary(profileId, index, newName)
-    local library = CustomProfile.GetProfileLibrary(profileId)
-    if not library or not library.profiles or not library.profiles[index] then return false end
-    library.profiles[index].name = newName
-    return true
-end
 
 function CustomProfile.GetLibraryCount(profileId)
     local library = CustomProfile.GetProfileLibrary(profileId)

--- a/CustomProfile.lua
+++ b/CustomProfile.lua
@@ -119,7 +119,14 @@ function CustomProfile.SaveCustomData(profileId, data)
     local library = TrueShotDB.customProfiles[profileId]
     if library and library.profiles then
         local idx = library.activeIndex or 1
-        library.profiles[idx] = data
+        if idx < 1 then
+            -- activeIndex 0 means built-in was active; append as new entry
+            data.name = data.name or "Custom"
+            library.profiles[#library.profiles + 1] = data
+            library.activeIndex = #library.profiles
+        else
+            library.profiles[idx] = data
+        end
     else
         data.name = data.name or "Custom"
         TrueShotDB.customProfiles[profileId] = {
@@ -158,7 +165,7 @@ end
 function CustomProfile.SetActiveIndex(profileId, index)
     local library = CustomProfile.GetProfileLibrary(profileId)
     if not library or not library.profiles then return false end
-    if index < 1 or index > #library.profiles then return false end
+    if index < 0 or index > #library.profiles then return false end
     library.activeIndex = index
     CustomProfile.InvalidateWrapper(profileId)
     return true

--- a/Display.lua
+++ b/Display.lua
@@ -748,11 +748,6 @@ local function UpdateAoeHintIcon(spellID)
     end
 end
 
-local function ResetAoeHintStabilization()
-    aoeHintPending = nil
-    aoeHintPendingTicks = 0
-end
-
 ------------------------------------------------------------------------
 -- HeartbeatStrip: scrolling GCD rhythm visualization
 ------------------------------------------------------------------------

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -763,7 +763,21 @@ function ProfileIO.Validate(data)
         local baseProfile = ResolveBaseProfile(data.profileId)
         if not baseProfile then
             errors[#errors + 1] = "Profile '" .. data.profileId .. "' not available on this character"
-        else
+        elseif baseProfile.specID then
+            -- Verify this character can actually use this spec
+            local canUseSpec = false
+            if GetSpecialization and GetSpecializationInfo then
+                for i = 1, GetNumSpecializations() do
+                    local specID = GetSpecializationInfo(i)
+                    if specID == baseProfile.specID then
+                        canUseSpec = true
+                        break
+                    end
+                end
+            end
+            if not canUseSpec then
+                errors[#errors + 1] = "Profile targets a spec not available to this character class"
+            end
             if data.specID and baseProfile.specID ~= data.specID then
                 errors[#errors + 1] = "specID mismatch: import has " .. data.specID .. ", local profile has " .. baseProfile.specID
             end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -629,10 +629,14 @@ function ProfileIO.Validate(data)
             if rule.reason ~= nil and type(rule.reason) ~= "string" then
                 errors[#errors + 1] = "Rule " .. i .. ": reason must be a string"
             end
-            if rule.condition then
-                local ok, err = ValidateConditionTree(rule.condition, 0, allowedConditions)
-                if not ok then
-                    errors[#errors + 1] = "Rule " .. i .. " condition: " .. err
+            if rule.condition ~= nil then
+                if type(rule.condition) ~= "table" then
+                    errors[#errors + 1] = "Rule " .. i .. ": condition must be a table or nil"
+                else
+                    local ok, err = ValidateConditionTree(rule.condition, 0, allowedConditions)
+                    if not ok then
+                        errors[#errors + 1] = "Rule " .. i .. " condition: " .. err
+                    end
                 end
             end
         end
@@ -709,10 +713,14 @@ function ProfileIO.Validate(data)
                         end
                     end
                 end
-                if trig.guard then
-                    local ok, err = ValidateConditionTree(trig.guard, 0, allowedConditions)
-                    if not ok then
-                        errors[#errors + 1] = "Trigger " .. i .. " guard: " .. err
+                if trig.guard ~= nil then
+                    if type(trig.guard) ~= "table" then
+                        errors[#errors + 1] = "Trigger " .. i .. ": guard must be a table or nil"
+                    else
+                        local ok, err = ValidateConditionTree(trig.guard, 0, allowedConditions)
+                        if not ok then
+                            errors[#errors + 1] = "Trigger " .. i .. " guard: " .. err
+                        end
                     end
                 end
             end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -520,12 +520,12 @@ local function BuildAllowedConditions(profileId, stateVarDefs)
     for id in pairs(ENGINE_CONDITION_IDS) do
         allowed[id] = true
     end
-    -- Base profile conditions (source == profileId only)
+    -- All registered condition schemas (multiple profiles may share condition
+    -- IDs like bw_on_cd or ba_ready; the registry is keyed by raw ID so only
+    -- the last registrant's source survives -- allow any known condition)
     local allSchemas = CustomProfile.GetAllConditionSchemas()
-    for id, schema in pairs(allSchemas) do
-        if schema.source == profileId then
-            allowed[id] = true
-        end
+    for id in pairs(allSchemas) do
+        allowed[id] = true
     end
     -- Imported state var names
     if stateVarDefs then

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -1377,8 +1377,26 @@ local function RefreshBrowser()
     local activeProfile = TrueShot.Engine and TrueShot.Engine.activeProfile
     local activeBaseId = activeProfile and (activeProfile._baseProfile or activeProfile).id
 
+    local INDENT = 16  -- pixels per depth level
     local rowIndex = 0
     local lastRow = nil
+    local lastRowDepth = 0
+
+    -- Place a row at the given depth, anchoring vertically below lastRow
+    -- but with absolute X offset from scrollChild based on depth
+    local function PlaceRow(row, depth, spacing)
+        row:ClearAllPoints()
+        if lastRow then
+            -- Anchor below previous row, but compute X offset relative to scrollChild
+            local xOffset = depth * INDENT
+            local prevX = lastRowDepth * INDENT
+            row:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", xOffset - prevX, spacing or -1)
+        else
+            row:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", depth * INDENT, 0)
+        end
+        lastRow = row
+        lastRowDepth = depth
+    end
 
     for _, className in ipairs(BROWSER_CLASS_ORDER) do
         local classData = tree[className]
@@ -1387,16 +1405,11 @@ local function RefreshBrowser()
             local classKey = "class:" .. className
             local classCollapsed = _collapsed[classKey]
 
-            -- Class header row
+            -- Class header row (depth 0)
             rowIndex = rowIndex + 1
             if rowIndex > MAX_ROWS then break end
             local classRow = rowPool[rowIndex]
-            classRow:ClearAllPoints()
-            if lastRow then
-                classRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 0, -2)
-            else
-                classRow:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", 0, 0)
-            end
+            PlaceRow(classRow, 0, -4)
             local classArrow = classCollapsed and "|cffaaaaaa>|r " or "|cffaaaaaav|r "
             classRow._text:SetText(classArrow .. "|cff" .. color .. className .. "|r")
             classRow._text:SetFontObject(GameFontNormal)
@@ -1405,7 +1418,6 @@ local function RefreshBrowser()
                 RefreshBrowser()
             end)
             classRow:Show()
-            lastRow = classRow
 
             if not classCollapsed then
                 local specs = SortedKeys(classData)
@@ -1414,12 +1426,11 @@ local function RefreshBrowser()
                     local specKey = "spec:" .. className .. "." .. specName
                     local specCollapsed = _collapsed[specKey]
 
-                    -- Spec header row
+                    -- Spec header row (depth 1)
                     rowIndex = rowIndex + 1
                     if rowIndex > MAX_ROWS then break end
                     local specRow = rowPool[rowIndex]
-                    specRow:ClearAllPoints()
-                    specRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+                    PlaceRow(specRow, 1)
                     local specArrow = specCollapsed and "|cffaaaaaa>|r " or "|cffaaaaaav|r "
                     specRow._text:SetText(specArrow .. "|cffdddddd" .. specName .. "|r")
                     specRow._text:SetFontObject(GameFontHighlight)
@@ -1428,7 +1439,6 @@ local function RefreshBrowser()
                         RefreshBrowser()
                     end)
                     specRow:Show()
-                    lastRow = specRow
 
                     if not specCollapsed then
                         local heroes = SortedKeys(specData)
@@ -1436,12 +1446,11 @@ local function RefreshBrowser()
                             local heroKey = "hero:" .. className .. "." .. specName .. "." .. heroName
                             local heroCollapsed = _collapsed[heroKey]
 
-                            -- Hero talent header row
+                            -- Hero talent header row (depth 2)
                             rowIndex = rowIndex + 1
                             if rowIndex > MAX_ROWS then break end
                             local heroRow = rowPool[rowIndex]
-                            heroRow:ClearAllPoints()
-                            heroRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+                            PlaceRow(heroRow, 2)
                             local heroArrow = heroCollapsed and "|cffaaaaaa>|r " or "|cffaaaaaav|r "
                             heroRow._text:SetText(heroArrow .. "|cffbbbbbb" .. heroName .. "|r")
                             heroRow._text:SetFontObject(GameFontHighlightSmall)
@@ -1450,7 +1459,6 @@ local function RefreshBrowser()
                                 RefreshBrowser()
                             end)
                             heroRow:Show()
-                            lastRow = heroRow
 
                             if not heroCollapsed then
                                 local profiles = specData[heroName]
@@ -1458,8 +1466,7 @@ local function RefreshBrowser()
                                     rowIndex = rowIndex + 1
                                     if rowIndex > MAX_ROWS then break end
                                     local profileRow = rowPool[rowIndex]
-                                    profileRow:ClearAllPoints()
-                                    profileRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+                                    PlaceRow(profileRow, 3)
 
                                     local name = profile.displayName or heroName
                                     local isActive = (profile.id == activeBaseId)
@@ -1501,7 +1508,6 @@ local function RefreshBrowser()
 
                                     profileRow:SetScript("OnClick", nil) -- no toggle on leaf rows
                                     profileRow:Show()
-                                    lastRow = profileRow
                                 end
                             end
                         end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -1,0 +1,766 @@
+-- TrueShot ProfileIO: import/export custom profiles as shareable strings
+-- Zero external dependencies. Custom serializer + Base64 codec.
+
+TrueShot = TrueShot or {}
+TrueShot.ProfileIO = {}
+
+local ProfileIO = TrueShot.ProfileIO
+local CustomProfile = TrueShot.CustomProfile
+
+local VERSION_HEADER = "!TS1!"
+
+------------------------------------------------------------------------
+-- Base64 Codec
+------------------------------------------------------------------------
+
+local B64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+local B64_ENCODE = {}
+local B64_DECODE = {}
+
+for i = 1, 64 do
+    local c = B64_CHARS:sub(i, i)
+    B64_ENCODE[i - 1] = c
+    B64_DECODE[c:byte()] = i - 1
+end
+
+local function Base64Encode(data)
+    local out = {}
+    local len = #data
+    for i = 1, len, 3 do
+        local b1 = data:byte(i)
+        local b2 = i + 1 <= len and data:byte(i + 1) or 0
+        local b3 = i + 2 <= len and data:byte(i + 2) or 0
+
+        out[#out + 1] = B64_ENCODE[math.floor(b1 / 4)]
+        out[#out + 1] = B64_ENCODE[(b1 % 4) * 16 + math.floor(b2 / 16)]
+
+        if i + 1 <= len then
+            out[#out + 1] = B64_ENCODE[(b2 % 16) * 4 + math.floor(b3 / 64)]
+        else
+            out[#out + 1] = "="
+        end
+
+        if i + 2 <= len then
+            out[#out + 1] = B64_ENCODE[b3 % 64]
+        else
+            out[#out + 1] = "="
+        end
+    end
+    return table.concat(out)
+end
+
+local function Base64Decode(data)
+    -- Strip whitespace and padding
+    data = data:gsub("%s", ""):gsub("=+$", "")
+    local out = {}
+    local len = #data
+    for i = 1, len, 4 do
+        local c1 = B64_DECODE[data:byte(i)] or 0
+        local c2 = i + 1 <= len and (B64_DECODE[data:byte(i + 1)] or 0) or 0
+        local c3 = i + 2 <= len and (B64_DECODE[data:byte(i + 2)] or 0) or 0
+        local c4 = i + 3 <= len and (B64_DECODE[data:byte(i + 3)] or 0) or 0
+
+        out[#out + 1] = string.char(c1 * 4 + math.floor(c2 / 16))
+        if i + 2 <= len then
+            out[#out + 1] = string.char((c2 % 16) * 16 + math.floor(c3 / 4))
+        end
+        if i + 3 <= len then
+            out[#out + 1] = string.char((c3 % 4) * 64 + c4)
+        end
+    end
+    return table.concat(out)
+end
+
+------------------------------------------------------------------------
+-- Serializer: Lua table -> string (known schema, BNF grammar)
+------------------------------------------------------------------------
+
+local function SerializeValue(val, depth)
+    if depth > 20 then return "nil" end
+    local vtype = type(val)
+
+    if vtype == "nil" then
+        return "nil"
+    elseif vtype == "boolean" then
+        return val and "true" or "false"
+    elseif vtype == "number" then
+        -- Reject non-finite numbers
+        if val ~= val or val == math.huge or val == -math.huge then
+            return "0"
+        end
+        -- Use integer format when possible
+        if val == math.floor(val) and val >= -2147483648 and val <= 2147483647 then
+            return string.format("%d", val)
+        end
+        return string.format("%.6g", val)
+    elseif vtype == "string" then
+        -- Escape special characters
+        local escaped = val:gsub("\\", "\\\\"):gsub('"', '\\"'):gsub("\n", "\\n"):gsub("\t", "\\t")
+        return '"' .. escaped .. '"'
+    elseif vtype == "table" then
+        local parts = {}
+        local nextDepth = depth + 1
+
+        -- Detect if this is an array (contiguous 1-based numeric keys)
+        local isArray = true
+        local maxKey = 0
+        local count = 0
+        for k in pairs(val) do
+            count = count + 1
+            if type(k) == "number" and k == math.floor(k) and k >= 1 then
+                if k > maxKey then maxKey = k end
+            else
+                isArray = false
+            end
+        end
+        if maxKey ~= count then isArray = false end
+
+        if isArray and count > 0 then
+            -- Serialize as array
+            for i = 1, count do
+                parts[#parts + 1] = SerializeValue(val[i], nextDepth)
+            end
+        else
+            -- Serialize as dictionary (sorted keys for deterministic output)
+            local keys = {}
+            for k in pairs(val) do keys[#keys + 1] = k end
+            table.sort(keys, function(a, b)
+                if type(a) == type(b) then return tostring(a) < tostring(b) end
+                return type(a) < type(b)
+            end)
+            for _, k in ipairs(keys) do
+                local v = val[k]
+                local keyStr
+                if type(k) == "number" then
+                    keyStr = "[" .. SerializeValue(k, nextDepth) .. "]"
+                elseif type(k) == "string" and k:match("^[a-zA-Z_][a-zA-Z0-9_]*$") then
+                    keyStr = k
+                else
+                    keyStr = "[" .. SerializeValue(tostring(k), nextDepth) .. "]"
+                end
+                parts[#parts + 1] = keyStr .. "=" .. SerializeValue(v, nextDepth)
+            end
+        end
+
+        return "{" .. table.concat(parts, ",") .. "}"
+    end
+
+    return "nil"
+end
+
+------------------------------------------------------------------------
+-- Deserializer: string -> Lua table (recursive descent parser)
+------------------------------------------------------------------------
+
+local function CreateParser(input)
+    local pos = 1
+    local len = #input
+    local depth = 0
+    local MAX_DEPTH = 20
+
+    local function peek()
+        return input:sub(pos, pos)
+    end
+
+    local function advance(n)
+        pos = pos + (n or 1)
+    end
+
+    local function skipWhitespace()
+        while pos <= len do
+            local c = input:byte(pos)
+            if c == 32 or c == 9 or c == 10 or c == 13 then -- space, tab, newline, cr
+                pos = pos + 1
+            else
+                break
+            end
+        end
+    end
+
+    local function expect(char)
+        skipWhitespace()
+        if peek() ~= char then
+            return nil, "Expected '" .. char .. "' at position " .. pos
+        end
+        advance()
+        return true
+    end
+
+    local function parseString()
+        skipWhitespace()
+        if peek() ~= '"' then return nil, "Expected string at position " .. pos end
+        advance() -- skip opening quote
+        local parts = {}
+        while pos <= len do
+            local c = peek()
+            if c == '"' then
+                advance() -- skip closing quote
+                return table.concat(parts)
+            elseif c == '\\' then
+                advance()
+                local escaped = peek()
+                if escaped == '\\' then parts[#parts + 1] = '\\'
+                elseif escaped == '"' then parts[#parts + 1] = '"'
+                elseif escaped == 'n' then parts[#parts + 1] = '\n'
+                elseif escaped == 't' then parts[#parts + 1] = '\t'
+                else parts[#parts + 1] = escaped
+                end
+                advance()
+            else
+                parts[#parts + 1] = c
+                advance()
+            end
+        end
+        return nil, "Unterminated string at position " .. pos
+    end
+
+    local function parseNumber()
+        skipWhitespace()
+        local startPos = pos
+        if peek() == '-' then advance() end
+        if pos > len or not input:sub(pos, pos):match("%d") then
+            return nil, "Expected number at position " .. startPos
+        end
+        while pos <= len and input:sub(pos, pos):match("%d") do advance() end
+        if pos <= len and peek() == '.' then
+            advance()
+            while pos <= len and input:sub(pos, pos):match("%d") do advance() end
+        end
+        local numStr = input:sub(startPos, pos - 1)
+        local val = tonumber(numStr)
+        if not val then return nil, "Invalid number at position " .. startPos end
+        return val
+    end
+
+    -- Forward declare parseValue
+    local parseValue
+
+    local function parseTable()
+        skipWhitespace()
+        local ok, err = expect("{")
+        if not ok then return nil, err end
+
+        depth = depth + 1
+        if depth > MAX_DEPTH then return nil, "Max nesting depth exceeded at position " .. pos end
+
+        local result = {}
+        local arrayIndex = 0
+        skipWhitespace()
+
+        if peek() == "}" then
+            advance()
+            depth = depth - 1
+            return result
+        end
+
+        while true do
+            skipWhitespace()
+            local key = nil
+
+            -- Check for explicit key: [number]= or identifier=
+            local savedPos = pos
+            if peek() == "[" then
+                advance()
+                local numKey, numErr = parseNumber()
+                if numKey then
+                    skipWhitespace()
+                    if peek() == "]" then
+                        advance()
+                        skipWhitespace()
+                        if peek() == "=" then
+                            advance()
+                            key = numKey
+                        end
+                    end
+                end
+                if not key then pos = savedPos end -- backtrack
+            end
+
+            if not key then
+                -- Try identifier=
+                local identStart = pos
+                while pos <= len and input:sub(pos, pos):match("[a-zA-Z0-9_]") do advance() end
+                if pos > identStart then
+                    skipWhitespace()
+                    if peek() == "=" then
+                        key = input:sub(identStart, pos - 1)
+                        advance() -- skip =
+                    else
+                        pos = identStart -- backtrack, treat as array value
+                    end
+                end
+            end
+
+            -- Parse value
+            local val, valErr = parseValue()
+            if val == nil and valErr then return nil, valErr end
+
+            if key then
+                result[key] = val
+            else
+                arrayIndex = arrayIndex + 1
+                result[arrayIndex] = val
+            end
+
+            skipWhitespace()
+            if peek() == "," then
+                advance()
+            elseif peek() == "}" then
+                advance()
+                depth = depth - 1
+                return result
+            else
+                return nil, "Expected ',' or '}' at position " .. pos
+            end
+        end
+    end
+
+    parseValue = function()
+        skipWhitespace()
+        if pos > len then return nil, "Unexpected end of input" end
+
+        local c = peek()
+
+        if c == '{' then
+            return parseTable()
+        elseif c == '"' then
+            return parseString()
+        elseif c == '-' or (c >= '0' and c <= '9') then
+            return parseNumber()
+        elseif input:sub(pos, pos + 3) == "true" then
+            advance(4)
+            return true
+        elseif input:sub(pos, pos + 4) == "false" then
+            advance(5)
+            return false
+        elseif input:sub(pos, pos + 2) == "nil" then
+            advance(3)
+            return nil -- Note: this makes nil indistinguishable from error; callers check err
+        else
+            return nil, "Unexpected character '" .. c .. "' at position " .. pos
+        end
+    end
+
+    return {
+        parse = function()
+            local result, err = parseValue()
+            if err then return nil, err end
+            skipWhitespace()
+            if pos <= len then
+                return nil, "Trailing data at position " .. pos
+            end
+            return result
+        end
+    }
+end
+
+------------------------------------------------------------------------
+-- Public API: Serialize / Deserialize / Encode / Decode
+------------------------------------------------------------------------
+
+function ProfileIO.Serialize(tbl)
+    return SerializeValue(tbl, 0)
+end
+
+function ProfileIO.Deserialize(str)
+    local parser = CreateParser(str)
+    return parser.parse()
+end
+
+function ProfileIO.Encode(profileData)
+    local serialized = ProfileIO.Serialize(profileData)
+    local encoded = Base64Encode(serialized)
+    return VERSION_HEADER .. encoded
+end
+
+function ProfileIO.Decode(importString)
+    -- Check version header
+    if not importString or type(importString) ~= "string" then
+        return nil, "Invalid input"
+    end
+    local version, payload = importString:match("^!TS(%d+)!(.+)$")
+    if not version or not payload then
+        return nil, "Invalid format: missing !TS1! header"
+    end
+    if version ~= "1" then
+        return nil, "Unsupported version: TS" .. version
+    end
+
+    -- Base64 decode
+    local decoded = Base64Decode(payload)
+    if not decoded or decoded == "" then
+        return nil, "Base64 decode failed"
+    end
+
+    -- Deserialize
+    local data, err = ProfileIO.Deserialize(decoded)
+    if not data then
+        return nil, "Deserialize failed: " .. (err or "unknown error")
+    end
+
+    if type(data) ~= "table" then
+        return nil, "Expected table, got " .. type(data)
+    end
+
+    -- Strip unknown top-level keys
+    local ALLOWED_KEYS = {
+        schemaVersion = true, profileId = true, specID = true,
+        markerSpell = true, displayName = true, rules = true,
+        stateVarDefs = true, triggers = true, rotationalSpells = true,
+    }
+    for k in pairs(data) do
+        if not ALLOWED_KEYS[k] then
+            data[k] = nil
+        end
+    end
+
+    return data
+end
+
+------------------------------------------------------------------------
+-- Validation
+------------------------------------------------------------------------
+
+local SCHEMA_VERSION = 1
+
+local VALID_RULE_TYPES = {
+    PIN = true, PREFER = true, BLACKLIST = true, BLACKLIST_CONDITIONAL = true,
+}
+
+local VALID_VAR_TYPES = {
+    boolean = true, number = true, timestamp = true,
+}
+
+local RESERVED_CONDITION_NAMES = {
+    ["and"] = true, ["or"] = true, ["not"] = true,
+}
+
+local ENGINE_CONDITION_IDS = {
+    spell_glowing = true, target_count = true, spell_charges = true,
+    usable = true, target_casting = true, in_combat = true,
+    burst_mode = true, combat_opening = true,
+}
+
+-- Validate array: contiguous 1-based numeric keys, no mixed string keys
+local function ValidateArray(tbl, fieldName)
+    if type(tbl) ~= "table" then
+        return false, fieldName .. " must be a table"
+    end
+    local maxKey = 0
+    local count = 0
+    for k in pairs(tbl) do
+        count = count + 1
+        if type(k) ~= "number" or k ~= math.floor(k) or k < 1 then
+            return false, fieldName .. " has non-integer key: " .. tostring(k)
+        end
+        if k > maxKey then maxKey = k end
+    end
+    if maxKey ~= count then
+        return false, fieldName .. " has holes (max key " .. maxKey .. ", count " .. count .. ")"
+    end
+    return true
+end
+
+-- Validate a condition tree (recursive)
+local function ValidateConditionTree(cond, depth, allowedConditions)
+    if cond == nil then return true end
+    if type(cond) ~= "table" then return false, "Condition must be a table" end
+    if depth > 4 then return false, "Condition nesting too deep (max 4)" end
+
+    local condType = cond.type
+    if type(condType) ~= "string" or condType == "" then
+        return false, "Condition missing type"
+    end
+
+    if condType == "and" or condType == "or" then
+        local ok, err = ValidateConditionTree(cond.left, depth + 1, allowedConditions)
+        if not ok then return false, err end
+        return ValidateConditionTree(cond.right, depth + 1, allowedConditions)
+    elseif condType == "not" then
+        return ValidateConditionTree(cond.inner, depth + 1, allowedConditions)
+    else
+        -- Primitive: must be in allowed set
+        if allowedConditions and not allowedConditions[condType] then
+            return false, "Unknown condition type: " .. condType
+        end
+        -- Validate param types if present
+        if cond.spellID ~= nil and type(cond.spellID) ~= "number" then
+            return false, "Condition spellID must be a number"
+        end
+        if cond.op ~= nil and type(cond.op) ~= "string" then
+            return false, "Condition op must be a string"
+        end
+        if cond.value ~= nil and type(cond.value) ~= "number" then
+            return false, "Condition value must be a number"
+        end
+        if cond.duration ~= nil and type(cond.duration) ~= "number" then
+            return false, "Condition duration must be a number"
+        end
+        if cond.seconds ~= nil and type(cond.seconds) ~= "number" then
+            return false, "Condition seconds must be a number"
+        end
+        return true
+    end
+end
+
+-- Build the allowed condition set for a given profile + imported state vars
+local function BuildAllowedConditions(profileId, stateVarDefs)
+    local allowed = {}
+    -- Engine conditions
+    for id in pairs(ENGINE_CONDITION_IDS) do
+        allowed[id] = true
+    end
+    -- Base profile conditions (source == profileId only)
+    local allSchemas = CustomProfile.GetAllConditionSchemas()
+    for id, schema in pairs(allSchemas) do
+        if schema.source == profileId then
+            allowed[id] = true
+        end
+    end
+    -- Imported state var names
+    if stateVarDefs then
+        for _, def in ipairs(stateVarDefs) do
+            if def.name then allowed[def.name] = true end
+        end
+    end
+    return allowed
+end
+
+-- Resolve the local base profile by profileId
+local function ResolveBaseProfile(profileId)
+    for specID, profiles in pairs(TrueShot.Profiles or {}) do
+        for _, profile in ipairs(profiles) do
+            if profile.id == profileId then
+                return profile
+            end
+        end
+    end
+    return nil
+end
+
+-- Full validation pipeline
+-- Returns: isValid (bool), errors (array of strings), warnings (array of strings)
+function ProfileIO.Validate(data)
+    local errors = {}
+    local warnings = {}
+
+    ------------------------------------------------------------------
+    -- Phase 2: Schema Validation
+    ------------------------------------------------------------------
+
+    -- Required fields
+    if type(data.schemaVersion) ~= "number" or data.schemaVersion < 1 then
+        errors[#errors + 1] = "Missing or invalid schemaVersion"
+    elseif data.schemaVersion > SCHEMA_VERSION then
+        errors[#errors + 1] = "Schema version " .. data.schemaVersion .. " is newer than supported (v" .. SCHEMA_VERSION .. ")"
+    end
+
+    if type(data.profileId) ~= "string" or data.profileId == "" then
+        errors[#errors + 1] = "Missing profileId"
+    end
+
+    if type(data.specID) ~= "number" or data.specID <= 0 then
+        errors[#errors + 1] = "Missing or invalid specID"
+    end
+
+    if type(data.rules) ~= "table" then
+        errors[#errors + 1] = "Missing rules table"
+        return #errors == 0, errors, warnings
+    end
+
+    -- Array validation
+    local arrayFields = { { data.rules, "rules" } }
+    if data.stateVarDefs then
+        arrayFields[#arrayFields + 1] = { data.stateVarDefs, "stateVarDefs" }
+    end
+    if data.triggers then
+        arrayFields[#arrayFields + 1] = { data.triggers, "triggers" }
+    end
+    for _, pair in ipairs(arrayFields) do
+        local ok, err = ValidateArray(pair[1], pair[2])
+        if not ok then errors[#errors + 1] = err end
+    end
+
+    -- Validate rotationalSpells
+    if data.rotationalSpells then
+        if type(data.rotationalSpells) ~= "table" then
+            errors[#errors + 1] = "rotationalSpells must be a table"
+        else
+            for k, v in pairs(data.rotationalSpells) do
+                if type(k) ~= "number" or k <= 0 or k ~= math.floor(k) then
+                    errors[#errors + 1] = "rotationalSpells has invalid key: " .. tostring(k)
+                    break
+                end
+                if v ~= true then
+                    errors[#errors + 1] = "rotationalSpells values must be true"
+                    break
+                end
+            end
+        end
+    end
+
+    -- Build allowed condition set (needs stateVarDefs for primitive validation)
+    local allowedConditions = nil
+    if data.profileId and type(data.profileId) == "string" then
+        allowedConditions = BuildAllowedConditions(data.profileId, data.stateVarDefs)
+    end
+
+    -- Validate each rule
+    for i, rule in ipairs(data.rules) do
+        if type(rule) ~= "table" then
+            errors[#errors + 1] = "Rule " .. i .. " is not a table"
+        else
+            if not rule.type or not VALID_RULE_TYPES[rule.type] then
+                errors[#errors + 1] = "Rule " .. i .. ": invalid type '" .. tostring(rule.type) .. "'"
+            end
+            if type(rule.spellID) ~= "number" or rule.spellID <= 0 then
+                errors[#errors + 1] = "Rule " .. i .. ": invalid spellID"
+            end
+            if rule.reason ~= nil and type(rule.reason) ~= "string" then
+                errors[#errors + 1] = "Rule " .. i .. ": reason must be a string"
+            end
+            if rule.condition then
+                local ok, err = ValidateConditionTree(rule.condition, 0, allowedConditions)
+                if not ok then
+                    errors[#errors + 1] = "Rule " .. i .. " condition: " .. err
+                end
+            end
+        end
+    end
+
+    -- Validate stateVarDefs
+    local varNames = {}
+    if data.stateVarDefs then
+        for i, def in ipairs(data.stateVarDefs) do
+            if type(def) ~= "table" then
+                errors[#errors + 1] = "stateVarDef " .. i .. " is not a table"
+            else
+                if type(def.name) ~= "string" or not def.name:match("^[a-zA-Z_][a-zA-Z0-9_]*$") then
+                    errors[#errors + 1] = "stateVarDef " .. i .. ": invalid name '" .. tostring(def.name) .. "'"
+                end
+                if not VALID_VAR_TYPES[def.varType] then
+                    errors[#errors + 1] = "stateVarDef " .. i .. ": invalid varType '" .. tostring(def.varType) .. "'"
+                end
+                -- Type-check default value
+                if def.varType == "boolean" and type(def.default) ~= "boolean" then
+                    errors[#errors + 1] = "stateVarDef " .. i .. ": default must be boolean"
+                elseif (def.varType == "number" or def.varType == "timestamp") and type(def.default) ~= "number" then
+                    errors[#errors + 1] = "stateVarDef " .. i .. ": default must be a number"
+                end
+                if def.name then varNames[def.name] = (varNames[def.name] or 0) + 1 end
+            end
+        end
+    end
+
+    -- Validate triggers
+    if data.triggers then
+        for i, trig in ipairs(data.triggers) do
+            if type(trig) ~= "table" then
+                errors[#errors + 1] = "Trigger " .. i .. " is not a table"
+            else
+                if type(trig.spellID) ~= "number" or trig.spellID <= 0 then
+                    errors[#errors + 1] = "Trigger " .. i .. ": invalid spellID"
+                end
+                if type(trig.varName) ~= "string" or not varNames[trig.varName] then
+                    errors[#errors + 1] = "Trigger " .. i .. ": varName '" .. tostring(trig.varName) .. "' not found in stateVarDefs"
+                end
+                if trig.guard then
+                    local ok, err = ValidateConditionTree(trig.guard, 0, allowedConditions)
+                    if not ok then
+                        errors[#errors + 1] = "Trigger " .. i .. " guard: " .. err
+                    end
+                end
+            end
+        end
+    end
+
+    ------------------------------------------------------------------
+    -- Phase 3: Semantic Validation
+    ------------------------------------------------------------------
+
+    -- State var name conflicts
+    if data.stateVarDefs then
+        for _, def in ipairs(data.stateVarDefs) do
+            local name = def.name
+            if name then
+                if RESERVED_CONDITION_NAMES[name] then
+                    errors[#errors + 1] = "State var '" .. name .. "' conflicts with reserved operator"
+                end
+                if ENGINE_CONDITION_IDS[name] then
+                    errors[#errors + 1] = "State var '" .. name .. "' conflicts with engine condition"
+                end
+                -- Check base profile conditions (source == profileId only)
+                if data.profileId then
+                    local allSchemas = CustomProfile.GetAllConditionSchemas()
+                    for id, schema in pairs(allSchemas) do
+                        if schema.source == data.profileId and id == name then
+                            errors[#errors + 1] = "State var '" .. name .. "' conflicts with profile condition"
+                        end
+                    end
+                end
+                if varNames[name] and varNames[name] > 1 then
+                    errors[#errors + 1] = "Duplicate state var name: " .. name
+                end
+            end
+        end
+    end
+
+    -- Profile resolution
+    if data.profileId and type(data.profileId) == "string" then
+        local baseProfile = ResolveBaseProfile(data.profileId)
+        if not baseProfile then
+            errors[#errors + 1] = "Profile '" .. data.profileId .. "' not available on this character"
+        else
+            if data.specID and baseProfile.specID ~= data.specID then
+                errors[#errors + 1] = "specID mismatch: import has " .. data.specID .. ", local profile has " .. baseProfile.specID
+            end
+            if data.markerSpell and baseProfile.markerSpell and data.markerSpell ~= baseProfile.markerSpell then
+                errors[#errors + 1] = "markerSpell mismatch"
+            end
+        end
+    end
+
+    ------------------------------------------------------------------
+    -- Phase 4: Warnings
+    ------------------------------------------------------------------
+
+    -- SpellID availability
+    if IsPlayerSpell then
+        for _, rule in ipairs(data.rules) do
+            if rule.spellID and not IsPlayerSpell(rule.spellID) then
+                local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(rule.spellID) or rule.spellID
+                warnings[#warnings + 1] = "Spell " .. tostring(name) .. " not known by this character"
+                break -- one warning is enough
+            end
+        end
+    end
+
+    -- Different spec warning
+    local currentSpecID = nil
+    if GetSpecialization and GetSpecializationInfo then
+        local specIndex = GetSpecialization()
+        if specIndex then currentSpecID = GetSpecializationInfo(specIndex) end
+    end
+    if data.specID and currentSpecID and data.specID ~= currentSpecID then
+        warnings[#warnings + 1] = "Profile targets a different spec (will activate when you switch)"
+    end
+
+    return #errors == 0, errors, warnings
+end
+
+-- Normalize imported data for storage
+function ProfileIO.Normalize(data)
+    local baseProfile = ResolveBaseProfile(data.profileId)
+    if not baseProfile then return nil, "Profile not found" end
+
+    local normalized = {
+        schemaVersion = SCHEMA_VERSION,
+        baseProfileId = data.profileId,
+        baseProfileVersion = baseProfile.version or 0,
+        rules = data.rules or {},
+        stateVarDefs = data.stateVarDefs or {},
+        triggers = data.triggers or {},
+        rotationalSpells = data.rotationalSpells or {},
+    }
+    return normalized
+end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -1119,7 +1119,11 @@ local function CreateImportFrame()
         end
 
         local profileId = _pendingData.profileId
-        CustomProfile.SaveCustomData(profileId, normalized)
+        -- Add to library (does not overwrite existing profiles)
+        normalized.name = _pendingData.displayName or ("Import " .. date("%H:%M"))
+        local newIndex = CustomProfile.AddToLibrary(profileId, normalized)
+        -- Switch to the newly imported profile
+        CustomProfile.SetActiveIndex(profileId, newIndex)
         CustomProfile.InvalidateWrapper(profileId)
         CustomProfile.RegisterCustomConditions(profileId, normalized.stateVarDefs)
 

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -764,3 +764,331 @@ function ProfileIO.Normalize(data)
     }
     return normalized
 end
+
+------------------------------------------------------------------------
+-- Export Frame
+------------------------------------------------------------------------
+
+local _exportFrame = nil
+
+local function CreateExportFrame()
+    local f = CreateFrame("Frame", "TrueShotExportFrame", UIParent, "BackdropTemplate")
+    f:SetSize(500, 280)
+    f:SetPoint("CENTER")
+    f:SetFrameStrata("DIALOG")
+    f:SetMovable(true)
+    f:EnableMouse(true)
+    f:SetClampedToScreen(true)
+    f:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        edgeSize = 14,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+    f:SetBackdropColor(0.08, 0.08, 0.12, 0.95)
+    f:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+
+    -- Title bar
+    local titleBar = CreateFrame("Frame", nil, f)
+    titleBar:SetHeight(24)
+    titleBar:SetPoint("TOPLEFT", f, "TOPLEFT", 4, -4)
+    titleBar:SetPoint("TOPRIGHT", f, "TOPRIGHT", -4, -4)
+    titleBar:EnableMouse(true)
+    titleBar:RegisterForDrag("LeftButton")
+    titleBar:SetScript("OnDragStart", function() f:StartMoving() end)
+    titleBar:SetScript("OnDragStop", function() f:StopMovingOrSizing() end)
+
+    local title = titleBar:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    title:SetPoint("LEFT", titleBar, "LEFT", 8, 0)
+    title:SetText("|cffabd473Export Profile|r")
+
+    local subtitle = f:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    subtitle:SetPoint("TOPLEFT", titleBar, "BOTTOMLEFT", 8, -4)
+    f._subtitle = subtitle
+
+    -- Close button
+    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
+    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
+    closeBtn:SetScript("OnClick", function() f:Hide() end)
+
+    -- Scroll frame for editbox
+    local scroll = CreateFrame("ScrollFrame", "TrueShotExportScroll", f, "UIPanelScrollFrameTemplate")
+    scroll:SetPoint("TOPLEFT", subtitle, "BOTTOMLEFT", 0, -8)
+    scroll:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -30, 40)
+
+    local editBox = CreateFrame("EditBox", "TrueShotExportEditBox", scroll)
+    editBox:SetMultiLine(true)
+    editBox:SetAutoFocus(false)
+    editBox:SetFontObject(GameFontHighlightSmall)
+    editBox:SetWidth(scroll:GetWidth() or 440)
+    editBox:SetMaxLetters(0)
+    scroll:SetScrollChild(editBox)
+    f._editBox = editBox
+
+    -- Close button at bottom
+    local bottomClose = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+    bottomClose:SetSize(80, 22)
+    bottomClose:SetPoint("BOTTOM", f, "BOTTOM", 0, 10)
+    bottomClose:SetText("Close")
+    bottomClose:SetScript("OnClick", function() f:Hide() end)
+
+    f:Hide()
+    return f
+end
+
+function ProfileIO:ShowExport()
+    local Engine = TrueShot.Engine
+    local profile = Engine and Engine.activeProfile
+    if not profile then
+        print("|cffff0000[TS]|r No active profile.")
+        return
+    end
+
+    local baseProfile = profile._baseProfile or profile
+    local profileId = baseProfile.id
+    local customData = CustomProfile.GetCustomData(profileId)
+
+    if not customData then
+        print("|cffff0000[TS]|r No custom profile to export. Customize first via /ts rules.")
+        return
+    end
+
+    -- Build export payload
+    local payload = {
+        schemaVersion = customData.schemaVersion or SCHEMA_VERSION,
+        profileId = profileId,
+        specID = baseProfile.specID,
+        markerSpell = baseProfile.markerSpell,
+        displayName = baseProfile.displayName or profileId,
+        rules = customData.rules,
+        stateVarDefs = customData.stateVarDefs,
+        triggers = customData.triggers,
+        rotationalSpells = customData.rotationalSpells,
+    }
+
+    local exportString = ProfileIO.Encode(payload)
+
+    if not _exportFrame then
+        _exportFrame = CreateExportFrame()
+    end
+
+    _exportFrame._subtitle:SetText("|cffaaaaaa" .. (baseProfile.displayName or profileId) .. "|r")
+    _exportFrame._editBox:SetText(exportString)
+    _exportFrame:Show()
+
+    -- Delayed focus and highlight for copy UX
+    C_Timer.After(0, function()
+        if _exportFrame:IsShown() then
+            _exportFrame._editBox:SetFocus()
+            _exportFrame._editBox:HighlightText()
+        end
+    end)
+end
+
+------------------------------------------------------------------------
+-- Import Frame
+------------------------------------------------------------------------
+
+local _importFrame = nil
+
+local function CreateImportFrame()
+    local f = CreateFrame("Frame", "TrueShotImportFrame", UIParent, "BackdropTemplate")
+    f:SetSize(500, 420)
+    f:SetPoint("CENTER")
+    f:SetFrameStrata("DIALOG")
+    f:SetMovable(true)
+    f:EnableMouse(true)
+    f:SetClampedToScreen(true)
+    f:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        edgeSize = 14,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+    f:SetBackdropColor(0.08, 0.08, 0.12, 0.95)
+    f:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+
+    -- Title bar
+    local titleBar = CreateFrame("Frame", nil, f)
+    titleBar:SetHeight(24)
+    titleBar:SetPoint("TOPLEFT", f, "TOPLEFT", 4, -4)
+    titleBar:SetPoint("TOPRIGHT", f, "TOPRIGHT", -4, -4)
+    titleBar:EnableMouse(true)
+    titleBar:RegisterForDrag("LeftButton")
+    titleBar:SetScript("OnDragStart", function() f:StartMoving() end)
+    titleBar:SetScript("OnDragStop", function() f:StopMovingOrSizing() end)
+
+    local title = titleBar:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    title:SetPoint("LEFT", titleBar, "LEFT", 8, 0)
+    title:SetText("|cffabd473Import Profile|r")
+
+    -- Close button
+    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
+    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
+    closeBtn:SetScript("OnClick", function() f:Hide() end)
+
+    -- Paste label
+    local pasteLabel = f:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    pasteLabel:SetPoint("TOPLEFT", titleBar, "BOTTOMLEFT", 8, -6)
+    pasteLabel:SetText("Paste import string below:")
+
+    -- Scroll frame for paste editbox
+    local scroll = CreateFrame("ScrollFrame", "TrueShotImportScroll", f, "UIPanelScrollFrameTemplate")
+    scroll:SetPoint("TOPLEFT", pasteLabel, "BOTTOMLEFT", 0, -4)
+    scroll:SetPoint("RIGHT", f, "RIGHT", -30, 0)
+    scroll:SetHeight(100)
+
+    local editBox = CreateFrame("EditBox", "TrueShotImportEditBox", scroll)
+    editBox:SetMultiLine(true)
+    editBox:SetAutoFocus(false)
+    editBox:SetFontObject(GameFontHighlightSmall)
+    editBox:SetWidth(scroll:GetWidth() or 440)
+    editBox:SetMaxLetters(0)
+    scroll:SetScrollChild(editBox)
+    f._editBox = editBox
+
+    -- Preview/Import button row
+    local previewBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+    previewBtn:SetSize(80, 22)
+    previewBtn:SetPoint("TOPLEFT", scroll, "BOTTOMLEFT", 0, -6)
+    previewBtn:SetText("Preview")
+    f._previewBtn = previewBtn
+
+    local importBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+    importBtn:SetSize(80, 22)
+    importBtn:SetPoint("LEFT", previewBtn, "RIGHT", 6, 0)
+    importBtn:SetText("Import")
+    importBtn:Disable()
+    f._importBtn = importBtn
+
+    local cancelBtn = CreateFrame("Button", nil, f, "UIPanelButtonTemplate")
+    cancelBtn:SetSize(80, 22)
+    cancelBtn:SetPoint("LEFT", importBtn, "RIGHT", 6, 0)
+    cancelBtn:SetText("Cancel")
+    cancelBtn:SetScript("OnClick", function() f:Hide() end)
+
+    -- Preview area
+    local previewArea = CreateFrame("Frame", nil, f)
+    previewArea:SetPoint("TOPLEFT", previewBtn, "BOTTOMLEFT", 0, -8)
+    previewArea:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -12, 10)
+
+    local previewText = previewArea:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    previewText:SetPoint("TOPLEFT", previewArea, "TOPLEFT", 0, 0)
+    previewText:SetPoint("RIGHT", previewArea, "RIGHT", 0, 0)
+    previewText:SetJustifyH("LEFT")
+    previewText:SetJustifyV("TOP")
+    previewText:SetWordWrap(true)
+    f._previewText = previewText
+
+    -- Wire preview button
+    local _pendingData = nil
+    previewBtn:SetScript("OnClick", function()
+        local inputStr = editBox:GetText()
+        if not inputStr or inputStr == "" then
+            previewText:SetText("|cffff0000No input.|r")
+            importBtn:Disable()
+            return
+        end
+
+        local data, decodeErr = ProfileIO.Decode(inputStr)
+        if not data then
+            previewText:SetText("|cffff0000" .. (decodeErr or "Decode failed") .. "|r")
+            importBtn:Disable()
+            return
+        end
+
+        local valid, errors, warnings = ProfileIO.Validate(data)
+        local lines = {}
+
+        -- Profile info
+        lines[#lines + 1] = "|cffabd473Profile:|r " .. (data.displayName or data.profileId or "?")
+        lines[#lines + 1] = "|cffabd473Spec:|r " .. tostring(data.specID or "?")
+        lines[#lines + 1] = "|cffabd473Rules:|r " .. (#(data.rules or {}))
+        lines[#lines + 1] = "|cffabd473State Vars:|r " .. (#(data.stateVarDefs or {}))
+        lines[#lines + 1] = "|cffabd473Triggers:|r " .. (#(data.triggers or {}))
+        lines[#lines + 1] = ""
+
+        if valid then
+            lines[#lines + 1] = "|cff00ff00Validation passed.|r"
+        else
+            lines[#lines + 1] = "|cffff0000Validation failed:|r"
+            for _, err in ipairs(errors) do
+                lines[#lines + 1] = "  |cffff4444- " .. err .. "|r"
+            end
+        end
+
+        if #warnings > 0 then
+            lines[#lines + 1] = ""
+            lines[#lines + 1] = "|cffffff00Warnings:|r"
+            for _, w in ipairs(warnings) do
+                lines[#lines + 1] = "  |cffffff88- " .. w .. "|r"
+            end
+        end
+
+        previewText:SetText(table.concat(lines, "\n"))
+
+        if valid then
+            _pendingData = data
+            importBtn:Enable()
+        else
+            _pendingData = nil
+            importBtn:Disable()
+        end
+    end)
+
+    -- Wire import button
+    importBtn:SetScript("OnClick", function()
+        if not _pendingData then return end
+
+        local normalized, normErr = ProfileIO.Normalize(_pendingData)
+        if not normalized then
+            previewText:SetText("|cffff0000" .. (normErr or "Normalization failed") .. "|r")
+            return
+        end
+
+        local profileId = _pendingData.profileId
+        CustomProfile.SaveCustomData(profileId, normalized)
+        CustomProfile.InvalidateWrapper(profileId)
+        CustomProfile.RegisterCustomConditions(profileId, normalized.stateVarDefs)
+
+        -- Re-activate if on matching spec
+        local currentSpecID = nil
+        if GetSpecialization and GetSpecializationInfo then
+            local specIndex = GetSpecialization()
+            if specIndex then currentSpecID = GetSpecializationInfo(specIndex) end
+        end
+        if _pendingData.specID and currentSpecID == _pendingData.specID then
+            TrueShot.Engine:ActivateProfile(currentSpecID)
+        end
+
+        -- Refresh Rule Builder if open
+        if TrueShot.RuleBuilder and TrueShot.RuleBuilder.Open then
+            local rbFrame = TrueShotRuleBuilder
+            if rbFrame and rbFrame:IsShown() then
+                TrueShot.RuleBuilder:Open()
+            end
+        end
+
+        print("|cff00ff00[TS]|r Profile imported: " .. (_pendingData.displayName or profileId))
+        _pendingData = nil
+        f:Hide()
+    end)
+
+    f:Hide()
+    return f
+end
+
+function ProfileIO:ShowImport()
+    if not _importFrame then
+        _importFrame = CreateImportFrame()
+    end
+    _importFrame._editBox:SetText("")
+    _importFrame._previewText:SetText("")
+    _importFrame._importBtn:Disable()
+    _importFrame:Show()
+    C_Timer.After(0, function()
+        if _importFrame:IsShown() then
+            _importFrame._editBox:SetFocus()
+        end
+    end)
+end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -1182,3 +1182,384 @@ function ProfileIO:ShowImport()
         end
     end)
 end
+
+------------------------------------------------------------------------
+-- Profile Browser: hierarchical Class > Spec > Hero Talent tree
+------------------------------------------------------------------------
+
+local BROWSER_SPEC_INFO = {
+    [253]  = { class = "Hunter",       spec = "Beast Mastery" },
+    [254]  = { class = "Hunter",       spec = "Marksmanship" },
+    [255]  = { class = "Hunter",       spec = "Survival" },
+    [577]  = { class = "Demon Hunter", spec = "Havoc" },
+    [1480] = { class = "Demon Hunter", spec = "Devourer" },
+    [102]  = { class = "Druid",        spec = "Balance" },
+    [103]  = { class = "Druid",        spec = "Feral" },
+    [62]   = { class = "Mage",         spec = "Arcane" },
+    [63]   = { class = "Mage",         spec = "Fire" },
+    [64]   = { class = "Mage",         spec = "Frost" },
+}
+
+local BROWSER_CLASS_ORDER = { "Hunter", "Demon Hunter", "Druid", "Mage" }
+
+local BROWSER_CLASS_COLORS = {
+    ["Hunter"]       = "abd473",
+    ["Demon Hunter"] = "a330c9",
+    ["Druid"]        = "ff7c0a",
+    ["Mage"]         = "3fc7eb",
+}
+
+local BROWSER_WIDTH = 520
+local BROWSER_HEIGHT = 500
+local ROW_HEIGHT = 22
+local MAX_ROWS = 60
+
+local _browserFrame = nil
+
+-- Extract hero talent name from profile id (e.g. "Hunter.BM.DarkRanger" -> "Dark Ranger")
+local function HeroTalentFromId(profileId)
+    local hero = profileId:match("^[^.]+%.[^.]+%.(.+)$")
+    if not hero then return nil end
+    -- CamelCase to spaced: "DarkRanger" -> "Dark Ranger"
+    return hero:gsub("(%u)", " %1"):gsub("^ ", "")
+end
+
+-- Build hierarchical tree: { class -> { spec -> { heroTalent -> {profiles} } } }
+local function BuildProfileTree()
+    local tree = {}
+    for specID, profiles in pairs(TrueShot.Profiles or {}) do
+        local info = BROWSER_SPEC_INFO[specID]
+        if info then
+            if not tree[info.class] then tree[info.class] = {} end
+            if not tree[info.class][info.spec] then tree[info.class][info.spec] = {} end
+            for _, profile in ipairs(profiles) do
+                local hero = HeroTalentFromId(profile.id) or profile.displayName or "Unknown"
+                if not tree[info.class][info.spec][hero] then
+                    tree[info.class][info.spec][hero] = {}
+                end
+                table.insert(tree[info.class][info.spec][hero], profile)
+            end
+        end
+    end
+    return tree
+end
+
+-- Sorted keys for deterministic display
+local function SortedKeys(tbl)
+    local keys = {}
+    for k in pairs(tbl) do keys[#keys + 1] = k end
+    table.sort(keys)
+    return keys
+end
+
+local function CreateBrowserFrame()
+    local f = CreateFrame("Frame", "TrueShotProfileBrowser", UIParent, "BackdropTemplate")
+    f:SetSize(BROWSER_WIDTH, BROWSER_HEIGHT)
+    f:SetPoint("CENTER")
+    f:SetFrameStrata("DIALOG")
+    f:SetMovable(true)
+    f:EnableMouse(true)
+    f:SetClampedToScreen(true)
+    f:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        edgeSize = 14,
+        insets = { left = 3, right = 3, top = 3, bottom = 3 },
+    })
+    f:SetBackdropColor(0.08, 0.08, 0.12, 0.95)
+    f:SetBackdropBorderColor(0.3, 0.3, 0.3, 1)
+
+    -- Title bar
+    local titleBar = CreateFrame("Frame", nil, f)
+    titleBar:SetHeight(28)
+    titleBar:SetPoint("TOPLEFT", f, "TOPLEFT", 4, -4)
+    titleBar:SetPoint("TOPRIGHT", f, "TOPRIGHT", -4, -4)
+    titleBar:EnableMouse(true)
+    titleBar:RegisterForDrag("LeftButton")
+    titleBar:SetScript("OnDragStart", function() f:StartMoving() end)
+    titleBar:SetScript("OnDragStop", function() f:StopMovingOrSizing() end)
+
+    local title = titleBar:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    title:SetPoint("LEFT", titleBar, "LEFT", 8, 0)
+    title:SetText("|cffabd473TrueShot|r Profile Browser")
+
+    local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
+    closeBtn:SetPoint("TOPRIGHT", f, "TOPRIGHT", -2, -2)
+    closeBtn:SetScript("OnClick", function() f:Hide() end)
+
+    -- Divider
+    local divider = f:CreateTexture(nil, "ARTWORK")
+    divider:SetHeight(1)
+    divider:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -34)
+    divider:SetPoint("TOPRIGHT", f, "TOPRIGHT", -8, -34)
+    divider:SetColorTexture(0.3, 0.3, 0.3, 1)
+
+    -- ScrollFrame
+    local scrollFrame = CreateFrame("ScrollFrame", "TrueShotBrowserScroll", f, "UIPanelScrollFrameTemplate")
+    scrollFrame:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -38)
+    scrollFrame:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -30, 10)
+
+    local scrollChild = CreateFrame("Frame", nil, scrollFrame)
+    scrollChild:SetWidth(BROWSER_WIDTH - 44)
+    scrollChild:SetHeight(1)
+    scrollFrame:SetScrollChild(scrollChild)
+    f._scrollChild = scrollChild
+
+    -- Row pool
+    local rowPool = {}
+    for i = 1, MAX_ROWS do
+        local row = CreateFrame("Button", nil, scrollChild)
+        row:SetSize(BROWSER_WIDTH - 50, ROW_HEIGHT)
+        row:Hide()
+
+        row._text = row:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+        row._text:SetPoint("LEFT", row, "LEFT", 0, 0)
+        row._text:SetPoint("RIGHT", row, "RIGHT", -130, 0)
+        row._text:SetJustifyH("LEFT")
+        row._text:SetWordWrap(false)
+
+        -- Action buttons (hidden by default, shown on profile rows)
+        local viewBtn = CreateFrame("Button", nil, row, "UIPanelButtonTemplate")
+        viewBtn:SetSize(50, 18)
+        viewBtn:SetPoint("RIGHT", row, "RIGHT", 0, 0)
+        viewBtn:SetText("View")
+        viewBtn:Hide()
+        row._viewBtn = viewBtn
+
+        local exportBtn = CreateFrame("Button", nil, row, "UIPanelButtonTemplate")
+        exportBtn:SetSize(55, 18)
+        exportBtn:SetPoint("RIGHT", viewBtn, "LEFT", -4, 0)
+        exportBtn:SetText("Export")
+        exportBtn:Hide()
+        row._exportBtn = exportBtn
+
+        -- Highlight on hover
+        local highlight = row:CreateTexture(nil, "HIGHLIGHT")
+        highlight:SetAllPoints()
+        highlight:SetColorTexture(1, 1, 1, 0.05)
+
+        rowPool[i] = row
+    end
+    f._rowPool = rowPool
+
+    f:Hide()
+    return f
+end
+
+-- Collapsed state tracking per section key
+local _collapsed = {}
+
+local function ToggleCollapse(key)
+    _collapsed[key] = not _collapsed[key]
+end
+
+local function RefreshBrowser()
+    if not _browserFrame then return end
+    local scrollChild = _browserFrame._scrollChild
+    local rowPool = _browserFrame._rowPool
+    local tree = BuildProfileTree()
+
+    -- Hide all rows
+    for _, row in ipairs(rowPool) do
+        row:Hide()
+        row._viewBtn:Hide()
+        row._exportBtn:Hide()
+        row:SetScript("OnClick", nil)
+    end
+
+    -- Determine current character's class and spec
+    local currentSpecID = nil
+    if GetSpecialization and GetSpecializationInfo then
+        local specIndex = GetSpecialization()
+        if specIndex then currentSpecID = GetSpecializationInfo(specIndex) end
+    end
+
+    local activeProfile = TrueShot.Engine and TrueShot.Engine.activeProfile
+    local activeBaseId = activeProfile and (activeProfile._baseProfile or activeProfile).id
+
+    local rowIndex = 0
+    local lastRow = nil
+
+    for _, className in ipairs(BROWSER_CLASS_ORDER) do
+        local classData = tree[className]
+        if classData then
+            local color = BROWSER_CLASS_COLORS[className] or "ffffff"
+            local classKey = "class:" .. className
+            local classCollapsed = _collapsed[classKey]
+
+            -- Class header row
+            rowIndex = rowIndex + 1
+            if rowIndex > MAX_ROWS then break end
+            local classRow = rowPool[rowIndex]
+            classRow:ClearAllPoints()
+            if lastRow then
+                classRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 0, -2)
+            else
+                classRow:SetPoint("TOPLEFT", scrollChild, "TOPLEFT", 0, 0)
+            end
+            local classArrow = classCollapsed and "|cffaaaaaa>|r " or "|cffaaaaaav|r "
+            classRow._text:SetText(classArrow .. "|cff" .. color .. className .. "|r")
+            classRow._text:SetFontObject(GameFontNormal)
+            classRow:SetScript("OnClick", function()
+                ToggleCollapse(classKey)
+                RefreshBrowser()
+            end)
+            classRow:Show()
+            lastRow = classRow
+
+            if not classCollapsed then
+                local specs = SortedKeys(classData)
+                for _, specName in ipairs(specs) do
+                    local specData = classData[specName]
+                    local specKey = "spec:" .. className .. "." .. specName
+                    local specCollapsed = _collapsed[specKey]
+
+                    -- Spec header row
+                    rowIndex = rowIndex + 1
+                    if rowIndex > MAX_ROWS then break end
+                    local specRow = rowPool[rowIndex]
+                    specRow:ClearAllPoints()
+                    specRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+                    local specArrow = specCollapsed and "|cffaaaaaa>|r " or "|cffaaaaaav|r "
+                    specRow._text:SetText(specArrow .. "|cffdddddd" .. specName .. "|r")
+                    specRow._text:SetFontObject(GameFontHighlight)
+                    specRow:SetScript("OnClick", function()
+                        ToggleCollapse(specKey)
+                        RefreshBrowser()
+                    end)
+                    specRow:Show()
+                    lastRow = specRow
+
+                    if not specCollapsed then
+                        local heroes = SortedKeys(specData)
+                        for _, heroName in ipairs(heroes) do
+                            local profiles = specData[heroName]
+                            for _, profile in ipairs(profiles) do
+                                rowIndex = rowIndex + 1
+                                if rowIndex > MAX_ROWS then break end
+                                local profileRow = rowPool[rowIndex]
+                                profileRow:ClearAllPoints()
+                                profileRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+
+                                local name = profile.displayName or heroName
+                                local isActive = (profile.id == activeBaseId)
+                                local hasCustom = CustomProfile.HasCustomData(profile.id)
+                                local suffix = ""
+                                if isActive and hasCustom then
+                                    suffix = "  |cff00ff00(active, customized)|r"
+                                elseif isActive then
+                                    suffix = "  |cff00ff00(active)|r"
+                                elseif hasCustom then
+                                    suffix = "  |cffaaaaaa(customized)|r"
+                                end
+
+                                local libCount = CustomProfile.GetLibraryCount(profile.id)
+                                if libCount > 1 then
+                                    suffix = suffix .. "  |cff888888[" .. libCount .. " variants]|r"
+                                end
+
+                                profileRow._text:SetText("|cffffffff" .. name .. "|r" .. suffix)
+                                profileRow._text:SetFontObject(isActive and GameFontGreen or GameFontHighlightSmall)
+
+                                -- View button: opens Rule Builder for this profile
+                                profileRow._viewBtn:Show()
+                                profileRow._viewBtn:SetScript("OnClick", function()
+                                    if profile.specID == currentSpecID then
+                                        -- Same spec: activate and open Rule Builder
+                                        TrueShot.Engine:ActivateProfile(profile.specID)
+                                        if TrueShot.RuleBuilder and TrueShot.RuleBuilder.Open then
+                                            TrueShot.RuleBuilder:Open()
+                                        end
+                                    else
+                                        -- Different spec: open read-only Rule Builder view
+                                        if TrueShot.RuleBuilder and TrueShot.RuleBuilder.OpenReadOnly then
+                                            TrueShot.RuleBuilder:OpenReadOnly(profile)
+                                        else
+                                            print("|cffffff00[TS]|r Cannot view profiles from other specs in Rule Builder.")
+                                        end
+                                    end
+                                    _browserFrame:Hide()
+                                end)
+
+                                -- Export button: show export string if customized
+                                if hasCustom then
+                                    profileRow._exportBtn:Show()
+                                    profileRow._exportBtn:SetScript("OnClick", function()
+                                        ProfileIO:ShowExportFor(profile)
+                                        _browserFrame:Hide()
+                                    end)
+                                end
+
+                                profileRow:SetScript("OnClick", nil) -- no toggle on leaf rows
+                                profileRow:Show()
+                                lastRow = profileRow
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    -- Update scroll child height
+    C_Timer.After(0, function()
+        if scrollChild:GetTop() and lastRow and lastRow:GetBottom() then
+            scrollChild:SetHeight(scrollChild:GetTop() - lastRow:GetBottom() + 20)
+        end
+    end)
+end
+
+-- Export a specific profile (not just the active one)
+function ProfileIO:ShowExportFor(profile)
+    local profileId = profile.id
+    local customData = CustomProfile.GetCustomData(profileId)
+    if not customData then
+        print("|cffff0000[TS]|r No custom data for " .. (profile.displayName or profileId) .. ".")
+        return
+    end
+
+    local payload = {
+        schemaVersion = customData.schemaVersion or 1,
+        profileId = profileId,
+        specID = profile.specID,
+        markerSpell = profile.markerSpell,
+        displayName = profile.displayName or profileId,
+        rules = customData.rules,
+        stateVarDefs = customData.stateVarDefs,
+        triggers = customData.triggers,
+        rotationalSpells = customData.rotationalSpells,
+    }
+
+    local exportString = ProfileIO.Encode(payload)
+
+    if not _exportFrame then
+        _exportFrame = CreateExportFrame()
+    end
+
+    _exportFrame._subtitle:SetText("|cffaaaaaa" .. (profile.displayName or profileId) .. "|r")
+    _exportFrame._editBox:SetText(exportString)
+    _exportFrame:Show()
+
+    C_Timer.After(0, function()
+        if _exportFrame:IsShown() then
+            _exportFrame._editBox:SetFocus()
+            _exportFrame._editBox:HighlightText()
+        end
+    end)
+end
+
+function ProfileIO:ShowBrowser()
+    if not _browserFrame then
+        _browserFrame = CreateBrowserFrame()
+    end
+    RefreshBrowser()
+    _browserFrame:Show()
+end
+
+function ProfileIO:ToggleBrowser()
+    if _browserFrame and _browserFrame:IsShown() then
+        _browserFrame:Hide()
+    else
+        self:ShowBrowser()
+    end
+end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -1433,66 +1433,76 @@ local function RefreshBrowser()
                     if not specCollapsed then
                         local heroes = SortedKeys(specData)
                         for _, heroName in ipairs(heroes) do
-                            local profiles = specData[heroName]
-                            for _, profile in ipairs(profiles) do
-                                rowIndex = rowIndex + 1
-                                if rowIndex > MAX_ROWS then break end
-                                local profileRow = rowPool[rowIndex]
-                                profileRow:ClearAllPoints()
-                                profileRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+                            local heroKey = "hero:" .. className .. "." .. specName .. "." .. heroName
+                            local heroCollapsed = _collapsed[heroKey]
 
-                                local name = profile.displayName or heroName
-                                local isActive = (profile.id == activeBaseId)
-                                local hasCustom = CustomProfile.HasCustomData(profile.id)
-                                local suffix = ""
-                                if isActive and hasCustom then
-                                    suffix = "  |cff00ff00(active, customized)|r"
-                                elseif isActive then
-                                    suffix = "  |cff00ff00(active)|r"
-                                elseif hasCustom then
-                                    suffix = "  |cffaaaaaa(customized)|r"
-                                end
+                            -- Hero talent header row
+                            rowIndex = rowIndex + 1
+                            if rowIndex > MAX_ROWS then break end
+                            local heroRow = rowPool[rowIndex]
+                            heroRow:ClearAllPoints()
+                            heroRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
+                            local heroArrow = heroCollapsed and "|cffaaaaaa>|r " or "|cffaaaaaav|r "
+                            heroRow._text:SetText(heroArrow .. "|cffbbbbbb" .. heroName .. "|r")
+                            heroRow._text:SetFontObject(GameFontHighlightSmall)
+                            heroRow:SetScript("OnClick", function()
+                                ToggleCollapse(heroKey)
+                                RefreshBrowser()
+                            end)
+                            heroRow:Show()
+                            lastRow = heroRow
 
-                                local libCount = CustomProfile.GetLibraryCount(profile.id)
-                                if libCount > 1 then
-                                    suffix = suffix .. "  |cff888888[" .. libCount .. " variants]|r"
-                                end
+                            if not heroCollapsed then
+                                local profiles = specData[heroName]
+                                for _, profile in ipairs(profiles) do
+                                    rowIndex = rowIndex + 1
+                                    if rowIndex > MAX_ROWS then break end
+                                    local profileRow = rowPool[rowIndex]
+                                    profileRow:ClearAllPoints()
+                                    profileRow:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", 16, -1)
 
-                                profileRow._text:SetText("|cffffffff" .. name .. "|r" .. suffix)
-                                profileRow._text:SetFontObject(isActive and GameFontGreen or GameFontHighlightSmall)
+                                    local name = profile.displayName or heroName
+                                    local isActive = (profile.id == activeBaseId)
+                                    local hasCustom = CustomProfile.HasCustomData(profile.id)
+                                    local suffix = ""
+                                    if isActive and hasCustom then
+                                        suffix = "  |cff00ff00(active, customized)|r"
+                                    elseif isActive then
+                                        suffix = "  |cff00ff00(active)|r"
+                                    elseif hasCustom then
+                                        suffix = "  |cffaaaaaa(customized)|r"
+                                    end
 
-                                -- View button: opens Rule Builder for this profile
-                                profileRow._viewBtn:Show()
-                                profileRow._viewBtn:SetScript("OnClick", function()
-                                    if profile.specID == currentSpecID then
-                                        -- Same spec: activate and open Rule Builder
-                                        TrueShot.Engine:ActivateProfile(profile.specID)
-                                        if TrueShot.RuleBuilder and TrueShot.RuleBuilder.Open then
-                                            TrueShot.RuleBuilder:Open()
-                                        end
-                                    else
-                                        -- Different spec: open read-only Rule Builder view
+                                    local libCount = CustomProfile.GetLibraryCount(profile.id)
+                                    if libCount > 1 then
+                                        suffix = suffix .. "  |cff888888[" .. libCount .. " variants]|r"
+                                    end
+
+                                    profileRow._text:SetText("|cffffffff" .. name .. "|r" .. suffix)
+                                    profileRow._text:SetFontObject(isActive and GameFontGreen or GameFontHighlightSmall)
+
+                                    -- View button: always opens read-only Rule Builder view
+                                    profileRow._viewBtn:Show()
+                                    profileRow._viewBtn:SetScript("OnClick", function()
                                         if TrueShot.RuleBuilder and TrueShot.RuleBuilder.OpenReadOnly then
                                             TrueShot.RuleBuilder:OpenReadOnly(profile)
-                                        else
-                                            print("|cffffff00[TS]|r Cannot view profiles from other specs in Rule Builder.")
                                         end
-                                    end
-                                    _browserFrame:Hide()
-                                end)
-
-                                -- Export button: show export string if customized
-                                if hasCustom then
-                                    profileRow._exportBtn:Show()
-                                    profileRow._exportBtn:SetScript("OnClick", function()
-                                        ProfileIO:ShowExportFor(profile)
                                         _browserFrame:Hide()
                                     end)
-                                end
 
-                                profileRow:SetScript("OnClick", nil) -- no toggle on leaf rows
-                                profileRow:Show()
-                                lastRow = profileRow
+                                    -- Export button: show export string if customized
+                                    if hasCustom then
+                                        profileRow._exportBtn:Show()
+                                        profileRow._exportBtn:SetScript("OnClick", function()
+                                            ProfileIO:ShowExportFor(profile)
+                                            _browserFrame:Hide()
+                                        end)
+                                    end
+
+                                    profileRow:SetScript("OnClick", nil) -- no toggle on leaf rows
+                                    profileRow:Show()
+                                    lastRow = profileRow
+                                end
                             end
                         end
                     end

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -1382,12 +1382,14 @@ local function RefreshBrowser()
     local lastRow = nil
     local lastRowDepth = 0
 
+    local baseRowWidth = BROWSER_WIDTH - 50
+
     -- Place a row at the given depth, anchoring vertically below lastRow
     -- but with absolute X offset from scrollChild based on depth
     local function PlaceRow(row, depth, spacing)
         row:ClearAllPoints()
+        row:SetWidth(baseRowWidth - depth * INDENT)
         if lastRow then
-            -- Anchor below previous row, but compute X offset relative to scrollChild
             local xOffset = depth * INDENT
             local prevX = lastRowDepth * INDENT
             row:SetPoint("TOPLEFT", lastRow, "BOTTOMLEFT", xOffset - prevX, spacing or -1)

--- a/ProfileIO.lua
+++ b/ProfileIO.lua
@@ -92,7 +92,8 @@ local function SerializeValue(val, depth)
         if val == math.floor(val) and val >= -2147483648 and val <= 2147483647 then
             return string.format("%d", val)
         end
-        return string.format("%.6g", val)
+        -- Use fixed decimal to avoid scientific notation (parser doesn't handle 'e')
+        return string.format("%.10f", val):gsub("0+$", "0"):gsub("%.$", ".0")
     elseif vtype == "string" then
         -- Escape special characters
         local escaped = val:gsub("\\", "\\\\"):gsub('"', '\\"'):gsub("\n", "\\n"):gsub("\t", "\\t")
@@ -473,10 +474,19 @@ local function ValidateConditionTree(cond, depth, allowedConditions)
     end
 
     if condType == "and" or condType == "or" then
+        if type(cond.left) ~= "table" then
+            return false, "'" .. condType .. "' condition missing 'left'"
+        end
+        if type(cond.right) ~= "table" then
+            return false, "'" .. condType .. "' condition missing 'right'"
+        end
         local ok, err = ValidateConditionTree(cond.left, depth + 1, allowedConditions)
         if not ok then return false, err end
         return ValidateConditionTree(cond.right, depth + 1, allowedConditions)
     elseif condType == "not" then
+        if type(cond.inner) ~= "table" then
+            return false, "'not' condition missing 'inner'"
+        end
         return ValidateConditionTree(cond.inner, depth + 1, allowedConditions)
     else
         -- Primitive: must be in allowed set
@@ -647,6 +657,9 @@ function ProfileIO.Validate(data)
                 elseif (def.varType == "number" or def.varType == "timestamp") and type(def.default) ~= "number" then
                     errors[#errors + 1] = "stateVarDef " .. i .. ": default must be a number"
                 end
+                if def.label ~= nil and type(def.label) ~= "string" then
+                    errors[#errors + 1] = "stateVarDef " .. i .. ": label must be a string or nil"
+                end
                 if def.name then varNames[def.name] = (varNames[def.name] or 0) + 1 end
             end
         end
@@ -663,6 +676,38 @@ function ProfileIO.Validate(data)
                 end
                 if type(trig.varName) ~= "string" or not varNames[trig.varName] then
                     errors[#errors + 1] = "Trigger " .. i .. ": varName '" .. tostring(trig.varName) .. "' not found in stateVarDefs"
+                end
+                -- Validate setNow
+                if trig.setNow ~= nil and type(trig.setNow) ~= "boolean" then
+                    errors[#errors + 1] = "Trigger " .. i .. ": setNow must be boolean or nil"
+                end
+                -- Validate resetAfter
+                if trig.resetAfter ~= nil then
+                    if type(trig.resetAfter) ~= "number" or trig.resetAfter <= 0 then
+                        errors[#errors + 1] = "Trigger " .. i .. ": resetAfter must be a positive number"
+                    end
+                end
+                -- Validate value type against referenced var
+                if trig.varName and varNames[trig.varName] then
+                    local refDef = nil
+                    for _, def in ipairs(data.stateVarDefs or {}) do
+                        if def.name == trig.varName then refDef = def; break end
+                    end
+                    if refDef and not trig.setNow then
+                        if refDef.varType == "boolean" and type(trig.value) ~= "boolean" then
+                            errors[#errors + 1] = "Trigger " .. i .. ": value must be boolean for var type " .. refDef.varType
+                        elseif (refDef.varType == "number" or refDef.varType == "timestamp") and type(trig.value) ~= "number" then
+                            errors[#errors + 1] = "Trigger " .. i .. ": value must be number for var type " .. refDef.varType
+                        end
+                    end
+                    -- Validate resetValue type
+                    if trig.resetValue ~= nil and refDef then
+                        if refDef.varType == "boolean" and type(trig.resetValue) ~= "boolean" then
+                            errors[#errors + 1] = "Trigger " .. i .. ": resetValue must be boolean"
+                        elseif (refDef.varType == "number" or refDef.varType == "timestamp") and type(trig.resetValue) ~= "number" then
+                            errors[#errors + 1] = "Trigger " .. i .. ": resetValue must be number"
+                        end
+                    end
                 end
                 if trig.guard then
                     local ok, err = ValidateConditionTree(trig.guard, 0, allowedConditions)
@@ -743,6 +788,25 @@ function ProfileIO.Validate(data)
     end
     if data.specID and currentSpecID and data.specID ~= currentSpecID then
         warnings[#warnings + 1] = "Profile targets a different spec (will activate when you switch)"
+    end
+
+    -- displayName differs from built-in
+    if data.profileId and data.displayName then
+        local baseProfile = ResolveBaseProfile(data.profileId)
+        if baseProfile and baseProfile.displayName and data.displayName ~= baseProfile.displayName then
+            warnings[#warnings + 1] = "Display name differs from built-in: '" .. data.displayName .. "'"
+        end
+    end
+
+    -- Trigger spell availability
+    if IsPlayerSpell and data.triggers then
+        for _, trig in ipairs(data.triggers) do
+            if trig.spellID and not IsPlayerSpell(trig.spellID) then
+                local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(trig.spellID) or trig.spellID
+                warnings[#warnings + 1] = "Trigger spell " .. tostring(name) .. " not known by this character"
+                break
+            end
+        end
     end
 
     return #errors == 0, errors, warnings

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -849,7 +849,11 @@ function RuleBuilder:OnReset()
     if not profile then return end
 
     local baseProfile = profile._baseProfile or profile
-    CustomProfile.DeleteCustomData(baseProfile.id)
+    -- Delete entire library (not just active entry)
+    if TrueShotDB.customProfiles then
+        TrueShotDB.customProfiles[baseProfile.id] = nil
+    end
+    CustomProfile.ClearCustomConditions(baseProfile.id)
     CustomProfile.InvalidateWrapper(baseProfile.id)
 
     -- Re-activate to revert to built-in

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -740,14 +740,20 @@ function RuleBuilder:OpenReadOnly(profile)
 
     _mainFrame._profileLabel:SetText("|cffaaaaaa" .. (profile.displayName or profileId) .. " (read-only)|r")
 
-    -- Load built-in rules as read-only
-    _editingData = {
-        rules = profile.rules or {},
-        stateVarDefs = {},
-        triggers = {},
-        rotationalSpells = profile.rotationalSpells or {},
-    }
-    _isCustomized = false
+    -- Load custom data if available, otherwise built-in rules
+    local customData = CustomProfile.GetCustomData(profileId)
+    if customData then
+        _editingData = DeepCopy(customData)
+        _isCustomized = true
+    else
+        _editingData = {
+            rules = DeepCopy(profile.rules or {}),
+            stateVarDefs = {},
+            triggers = {},
+            rotationalSpells = DeepCopy(profile.rotationalSpells or {}),
+        }
+        _isCustomized = false
+    end
     _isReadOnly = true
 
     _selectedIndex = nil
@@ -1515,7 +1521,7 @@ function RuleBuilder:ShowRuleEditor(index)
     self:ClearRightPanel()
     ClearEditorFrames()
 
-    if not _rightPanel or not _editingData or not _isCustomized then return end
+    if not _rightPanel or not _editingData or (not _isCustomized and not _isReadOnly) then return end
     local rules = _editingData.rules
     local rule = rules and rules[index]
     if not rule then return end
@@ -1744,7 +1750,7 @@ function RuleBuilder:ShowStateVarEditor(varIndex)
     self:ClearRightPanel()
     ClearEditorFrames()
 
-    if not _rightPanel or not _editingData or not _isCustomized then return end
+    if not _rightPanel or not _editingData or (not _isCustomized and not _isReadOnly) then return end
     local defs = _editingData.stateVarDefs
     local def = defs and defs[varIndex]
     if not def then return end

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -828,8 +828,16 @@ end
 local _hintText = nil  -- reusable hint FontString
 
 -- Recursively disable all interactive controls in a frame tree (read-only mode)
+-- For ScrollFrames: recurse into the scroll child (editor content) but skip
+-- the scrollbar children to preserve scroll functionality
 local function DisableFrameTree(frame)
     if not frame then return end
+    if frame:IsObjectType("ScrollFrame") then
+        -- Only recurse into the scroll child, not the scrollbar
+        local scrollChild = frame:GetScrollChild()
+        if scrollChild then DisableFrameTree(scrollChild) end
+        return
+    end
     local objType = frame:IsObjectType("Button") and "Button"
         or frame:IsObjectType("EditBox") and "EditBox"
         or nil

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -333,6 +333,17 @@ local function CreateMainFrame()
     end)
     f._importBtn = importBtn
 
+    local browseBtn = CreateFrame("Button", nil, bottomBar, "UIPanelButtonTemplate")
+    browseBtn:SetSize(80, 22)
+    browseBtn:SetPoint("RIGHT", importBtn, "LEFT", -6, 0)
+    browseBtn:SetText("Browse All")
+    browseBtn:SetScript("OnClick", function()
+        if TrueShot.ProfileIO and TrueShot.ProfileIO.ShowBrowser then
+            TrueShot.ProfileIO:ShowBrowser()
+        end
+    end)
+    f._browseBtn = browseBtn
+
     f:Hide()
     return f
 end
@@ -710,6 +721,43 @@ function RuleBuilder:Open()
         _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -38)
         _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
     end
+
+    self:RefreshRuleList()
+    self:UpdateButtonStates()
+    self:ClearRightPanel()
+    _mainFrame:Show()
+end
+
+-- Read-only view for cross-spec profiles from the Profile Browser
+function RuleBuilder:OpenReadOnly(profile)
+    if not _mainFrame then
+        _mainFrame = CreateMainFrame()
+    end
+
+    local profileId = profile.id
+
+    _mainFrame._profileLabel:SetText("|cffaaaaaa" .. (profile.displayName or profileId) .. " (read-only)|r")
+
+    -- Load built-in rules as read-only
+    _editingData = {
+        rules = profile.rules or {},
+        stateVarDefs = {},
+        triggers = {},
+        rotationalSpells = profile.rotationalSpells or {},
+    }
+    _isCustomized = false
+
+    _selectedIndex = nil
+    _selectedVarIndex = nil
+
+    -- Hide library selector for read-only
+    _mainFrame._libSelector:Hide()
+    _mainFrame._divider:ClearAllPoints()
+    _mainFrame._divider:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -34)
+    _mainFrame._divider:SetPoint("TOPRIGHT", _mainFrame, "TOPRIGHT", -8, -34)
+    _mainFrame._leftPanel:ClearAllPoints()
+    _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -38)
+    _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
 
     self:RefreshRuleList()
     self:UpdateButtonStates()

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -827,6 +827,35 @@ end
 
 local _hintText = nil  -- reusable hint FontString
 
+-- Disable all interactive controls in tracked editor frames (read-only mode)
+local function DisableEditorControls()
+    for _, frame in ipairs(_editorFrames) do
+        -- Disable buttons
+        if frame.Disable and frame:IsObjectType("Button") then
+            frame:Disable()
+        end
+        -- Disable editboxes
+        if frame:IsObjectType("EditBox") then
+            frame:SetEnabled(false)
+        end
+        -- Recurse into children
+        for i = 1, frame:GetNumChildren() do
+            local child = select(i, frame:GetChildren())
+            if child.Disable and child:IsObjectType("Button") then
+                child:Disable()
+            end
+            if child.SetEnabled and child:IsObjectType("EditBox") then
+                child:SetEnabled(false)
+            end
+            -- Dropdowns: disable their button child
+            if child:GetName() and child:GetName():find("DropDown") then
+                local ddBtn = _G[child:GetName() .. "Button"]
+                if ddBtn and ddBtn.Disable then ddBtn:Disable() end
+            end
+        end
+    end
+end
+
 function RuleBuilder:ClearRightPanel()
     -- Clear all children of the right panel
     if not _rightPanel then return end
@@ -976,6 +1005,7 @@ function RuleBuilder:SelectStateVar(index)
 end
 
 function RuleBuilder:DeleteStateVar(index)
+    if _isReadOnly then return end
     if not _editingData or not _isCustomized then return end
     -- Capture varName before removing the def
     local varName = (_editingData.stateVarDefs[index] or {}).name
@@ -1009,6 +1039,7 @@ function RuleBuilder:DeleteStateVar(index)
 end
 
 function RuleBuilder:MoveRule(index, direction)
+    if _isReadOnly then return end
     if not _editingData or not _isCustomized then return end
     local rules = _editingData.rules
     local newIndex = index + direction
@@ -1758,6 +1789,8 @@ function RuleBuilder:ShowRuleEditor(index)
             scrollChild:SetHeight(math.max(top - bottom + 40, 200))
         end
     end)
+
+    if _isReadOnly then DisableEditorControls() end
 end
 
 ------------------------------------------------------------------------
@@ -2061,6 +2094,8 @@ function RuleBuilder:ShowStateVarEditor(varIndex)
             scrollChild:SetHeight(math.max(top - bottom + 30, 300))
         end
     end)
+
+    if _isReadOnly then DisableEditorControls() end
 end
 
 ------------------------------------------------------------------------
@@ -2071,7 +2106,7 @@ function RuleBuilder:ShowTriggerEditor(varIndex, trigIndex)
     self:ClearRightPanel()
     ClearEditorFrames()
 
-    if not _rightPanel or not _editingData or not _isCustomized then return end
+    if not _rightPanel or not _editingData or (not _isCustomized and not _isReadOnly) then return end
     local def = _editingData.stateVarDefs and _editingData.stateVarDefs[varIndex]
     local trig = _editingData.triggers and _editingData.triggers[trigIndex]
     if not def or not trig then return end
@@ -2365,4 +2400,6 @@ function RuleBuilder:ShowTriggerEditor(varIndex, trigIndex)
             scrollChild:SetHeight(math.max(top - bottom + 30, 300))
         end
     end)
+
+    if _isReadOnly then DisableEditorControls() end
 end

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -827,32 +827,31 @@ end
 
 local _hintText = nil  -- reusable hint FontString
 
--- Disable all interactive controls in tracked editor frames (read-only mode)
+-- Recursively disable all interactive controls in a frame tree (read-only mode)
+local function DisableFrameTree(frame)
+    if not frame then return end
+    local objType = frame:IsObjectType("Button") and "Button"
+        or frame:IsObjectType("EditBox") and "EditBox"
+        or nil
+    if objType == "Button" and frame.Disable then
+        frame:Disable()
+    elseif objType == "EditBox" and frame.SetEnabled then
+        frame:SetEnabled(false)
+    end
+    -- Disable UIDropDownMenu button children (named *Button)
+    local name = frame:GetName()
+    if name then
+        local ddBtn = _G[name .. "Button"]
+        if ddBtn and ddBtn.Disable then ddBtn:Disable() end
+    end
+    for i = 1, frame:GetNumChildren() do
+        DisableFrameTree(select(i, frame:GetChildren()))
+    end
+end
+
 local function DisableEditorControls()
     for _, frame in ipairs(_editorFrames) do
-        -- Disable buttons
-        if frame.Disable and frame:IsObjectType("Button") then
-            frame:Disable()
-        end
-        -- Disable editboxes
-        if frame:IsObjectType("EditBox") then
-            frame:SetEnabled(false)
-        end
-        -- Recurse into children
-        for i = 1, frame:GetNumChildren() do
-            local child = select(i, frame:GetChildren())
-            if child.Disable and child:IsObjectType("Button") then
-                child:Disable()
-            end
-            if child.SetEnabled and child:IsObjectType("EditBox") then
-                child:SetEnabled(false)
-            end
-            -- Dropdowns: disable their button child
-            if child:GetName() and child:GetName():find("DropDown") then
-                local ddBtn = _G[child:GetName() .. "Button"]
-                if ddBtn and ddBtn.Disable then ddBtn:Disable() end
-            end
-        end
+        DisableFrameTree(frame)
     end
 end
 

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -65,6 +65,7 @@ local _selectedVarIndex = nil  -- index into stateVarDefs, or nil
 local _editingData = nil  -- the custom data being edited
 local _isCustomized = false
 local _isReadOnly = false
+local _viewedProfileId = nil  -- profile ID for read-only views
 local _editorFrames = {}  -- tracked frames for editor cleanup
 local RenderConditionTree  -- forward declaration for recursive rendering
 
@@ -137,6 +138,9 @@ local function GetRotationalSpellList()
 end
 
 local function GetProfileId()
+    if _isReadOnly and _viewedProfileId then
+        return _viewedProfileId
+    end
     local Engine = TrueShot.Engine
     local profile = Engine and Engine.activeProfile
     if not profile then return nil end
@@ -560,7 +564,7 @@ function RuleBuilder:RefreshRuleList()
                 row._selected:Hide()
             end
 
-            if _isCustomized then
+            if _isCustomized and not _isReadOnly then
                 row._upBtn:SetShown(i > 1)
                 row._downBtn:SetShown(i < #rules)
                 row._delBtn:Show()
@@ -610,7 +614,7 @@ function RuleBuilder:RefreshRuleList()
                 row._selected:Hide()
             end
 
-            if _isCustomized then
+            if _isCustomized and not _isReadOnly then
                 row._delBtn:Show()
             else
                 row._delBtn:Hide()
@@ -664,6 +668,7 @@ function RuleBuilder:Open()
     -- Update title
     _mainFrame._profileLabel:SetText("|cffaaaaaa" .. (baseProfile.displayName or profileId) .. "|r")
     _isReadOnly = false
+    _viewedProfileId = nil
 
     -- Load existing custom data or show built-in rules read-only
     local customData = CustomProfile.GetCustomData(profileId)
@@ -755,6 +760,12 @@ function RuleBuilder:OpenReadOnly(profile)
         _isCustomized = false
     end
     _isReadOnly = true
+    _viewedProfileId = profileId
+
+    -- Register custom state var conditions for the viewed profile
+    if _editingData.stateVarDefs then
+        CustomProfile.RegisterCustomConditions(profileId, _editingData.stateVarDefs)
+    end
 
     _selectedIndex = nil
     _selectedVarIndex = nil
@@ -851,6 +862,7 @@ end
 ------------------------------------------------------------------------
 
 function RuleBuilder:OnCustomize()
+    if _isReadOnly then return end
     local Engine = TrueShot.Engine
     local profile = Engine and Engine.activeProfile
     if not profile then return end
@@ -868,6 +880,7 @@ function RuleBuilder:OnCustomize()
 end
 
 function RuleBuilder:OnApply()
+    if _isReadOnly then return end
     if not _editingData or not _isCustomized then return end
 
     local Engine = TrueShot.Engine
@@ -913,6 +926,7 @@ function RuleBuilder:OnApply()
 end
 
 function RuleBuilder:OnReset()
+    if _isReadOnly then return end
     local Engine = TrueShot.Engine
     local profile = Engine and Engine.activeProfile
     if not profile then return end
@@ -934,6 +948,7 @@ function RuleBuilder:OnReset()
 end
 
 function RuleBuilder:OnDeleteLibraryEntry()
+    if _isReadOnly then return end
     local Engine = TrueShot.Engine
     local profile = Engine and Engine.activeProfile
     if not profile then return end
@@ -1011,6 +1026,7 @@ function RuleBuilder:MoveRule(index, direction)
 end
 
 function RuleBuilder:DeleteRule(index)
+    if _isReadOnly then return end
     if not _editingData or not _isCustomized then return end
     table.remove(_editingData.rules, index)
     if _selectedIndex == index then
@@ -1023,6 +1039,7 @@ function RuleBuilder:DeleteRule(index)
 end
 
 function RuleBuilder:OnAddRule()
+    if _isReadOnly then return end
     if not _editingData or not _isCustomized then return end
     local newRule = {
         type = "PIN",
@@ -1037,6 +1054,7 @@ function RuleBuilder:OnAddRule()
 end
 
 function RuleBuilder:OnAddStateVar()
+    if _isReadOnly then return end
     if not _editingData or not _isCustomized then return end
     local newVar = {
         name    = "var" .. (#_editingData.stateVarDefs + 1),

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -64,6 +64,7 @@ local _selectedIndex = nil
 local _selectedVarIndex = nil  -- index into stateVarDefs, or nil
 local _editingData = nil  -- the custom data being edited
 local _isCustomized = false
+local _isReadOnly = false
 local _editorFrames = {}  -- tracked frames for editor cleanup
 local RenderConditionTree  -- forward declaration for recursive rendering
 
@@ -662,6 +663,7 @@ function RuleBuilder:Open()
 
     -- Update title
     _mainFrame._profileLabel:SetText("|cffaaaaaa" .. (baseProfile.displayName or profileId) .. "|r")
+    _isReadOnly = false
 
     -- Load existing custom data or show built-in rules read-only
     local customData = CustomProfile.GetCustomData(profileId)
@@ -746,6 +748,7 @@ function RuleBuilder:OpenReadOnly(profile)
         rotationalSpells = profile.rotationalSpells or {},
     }
     _isCustomized = false
+    _isReadOnly = true
 
     _selectedIndex = nil
     _selectedVarIndex = nil
@@ -767,6 +770,17 @@ end
 
 function RuleBuilder:UpdateButtonStates()
     if not _mainFrame then return end
+    if _isReadOnly then
+        _mainFrame._customizeBtn:Hide()
+        _mainFrame._applyBtn:Hide()
+        _mainFrame._resetBtn:Hide()
+        _mainFrame._addRuleBtn:Hide()
+        _mainFrame._addVarBtn:Hide()
+        if _mainFrame._exportBtn then _mainFrame._exportBtn:Hide() end
+        if _mainFrame._importBtn then _mainFrame._importBtn:Hide() end
+        if _mainFrame._browseBtn then _mainFrame._browseBtn:Hide() end
+        return
+    end
     _mainFrame._customizeBtn:SetShown(not _isCustomized)
     _mainFrame._applyBtn:SetShown(_isCustomized)
     _mainFrame._resetBtn:SetShown(_isCustomized)
@@ -774,6 +788,7 @@ function RuleBuilder:UpdateButtonStates()
     _mainFrame._addVarBtn:SetShown(_isCustomized)
     if _mainFrame._exportBtn then _mainFrame._exportBtn:SetShown(_isCustomized) end
     if _mainFrame._importBtn then _mainFrame._importBtn:Show() end
+    if _mainFrame._browseBtn then _mainFrame._browseBtn:Show() end
 end
 
 ------------------------------------------------------------------------

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -282,6 +282,28 @@ local function CreateMainFrame()
     end)
     f._addVarBtn = addVarBtn
 
+    local exportBtn = CreateFrame("Button", nil, bottomBar, "UIPanelButtonTemplate")
+    exportBtn:SetSize(70, 22)
+    exportBtn:SetPoint("RIGHT", resetBtn, "LEFT", -6, 0)
+    exportBtn:SetText("Export")
+    exportBtn:SetScript("OnClick", function()
+        if TrueShot.ProfileIO and TrueShot.ProfileIO.ShowExport then
+            TrueShot.ProfileIO:ShowExport()
+        end
+    end)
+    f._exportBtn = exportBtn
+
+    local importBtn = CreateFrame("Button", nil, bottomBar, "UIPanelButtonTemplate")
+    importBtn:SetSize(70, 22)
+    importBtn:SetPoint("RIGHT", exportBtn, "LEFT", -6, 0)
+    importBtn:SetText("Import")
+    importBtn:SetScript("OnClick", function()
+        if TrueShot.ProfileIO and TrueShot.ProfileIO.ShowImport then
+            TrueShot.ProfileIO:ShowImport()
+        end
+    end)
+    f._importBtn = importBtn
+
     f:Hide()
     return f
 end
@@ -632,6 +654,8 @@ function RuleBuilder:UpdateButtonStates()
     _mainFrame._resetBtn:SetShown(_isCustomized)
     _mainFrame._addRuleBtn:SetShown(_isCustomized)
     _mainFrame._addVarBtn:SetShown(_isCustomized)
+    if _mainFrame._exportBtn then _mainFrame._exportBtn:SetShown(_isCustomized) end
+    if _mainFrame._importBtn then _mainFrame._importBtn:Show() end
 end
 
 ------------------------------------------------------------------------

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -202,7 +202,7 @@ local function CreateMainFrame()
     divider:SetColorTexture(0.3, 0.3, 0.3, 1)
     f._divider = divider
 
-    -- Profile library selector (hidden by default, shown when 2+ profiles exist)
+    -- Profile selector (always visible: built-in + custom entries)
     local libSelector = CreateFrame("Frame", nil, f)
     libSelector:SetHeight(26)
     libSelector:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -35)
@@ -212,7 +212,7 @@ local function CreateMainFrame()
 
     local libLabel = libSelector:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
     libLabel:SetPoint("LEFT", libSelector, "LEFT", 4, 0)
-    libLabel:SetText("Active:")
+    libLabel:SetText("Profile:")
     f._libLabel = libLabel
 
     local libDropdown = CreateFrame("Frame", "TrueShotRBLibDD", libSelector, "UIDropDownMenuTemplate")
@@ -689,45 +689,68 @@ function RuleBuilder:Open()
     _selectedIndex = nil
     _selectedVarIndex = nil
 
-    -- Profile library selector
-    local libraryCount = CustomProfile.GetLibraryCount and CustomProfile.GetLibraryCount(profileId) or 0
-    if _isCustomized and libraryCount > 1 then
-        _mainFrame._libSelector:Show()
-        -- Shift divider and left panel down to make room
-        _mainFrame._divider:ClearAllPoints()
-        _mainFrame._divider:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -60)
-        _mainFrame._divider:SetPoint("TOPRIGHT", _mainFrame, "TOPRIGHT", -8, -60)
-        _mainFrame._leftPanel:ClearAllPoints()
-        _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -64)
-        _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
+    -- Always-visible profile selector (built-in + custom entries)
+    _mainFrame._libSelector:Show()
+    _mainFrame._divider:ClearAllPoints()
+    _mainFrame._divider:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -60)
+    _mainFrame._divider:SetPoint("TOPRIGHT", _mainFrame, "TOPRIGHT", -8, -60)
+    _mainFrame._leftPanel:ClearAllPoints()
+    _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -64)
+    _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
 
-        local activeIdx = CustomProfile.GetActiveIndex(profileId)
-        local library = CustomProfile.GetProfileLibrary(profileId)
-        UIDropDownMenu_Initialize(_mainFrame._libDropdown, function()
+    local library = CustomProfile.GetProfileLibrary(profileId)
+    local activeIdx = library and CustomProfile.GetActiveIndex(profileId) or nil
+
+    UIDropDownMenu_Initialize(_mainFrame._libDropdown, function()
+        -- Built-in option (always first)
+        local info = UIDropDownMenu_CreateInfo()
+        info.text = "Built-in: " .. (baseProfile.displayName or profileId)
+        info.checked = (not _isCustomized)
+        info.func = function()
+            _isCustomized = false
+            _editingData = {
+                rules = baseProfile.rules or {},
+                stateVarDefs = {},
+                triggers = {},
+                rotationalSpells = baseProfile.rotationalSpells or {},
+            }
+            -- Tell the engine to use built-in (activeIndex 0 = none active)
+            if library then
+                CustomProfile.SetActiveIndex(profileId, 0)
+            end
+            CustomProfile.InvalidateWrapper(profileId)
+            TrueShot.Engine:ActivateProfile(baseProfile.specID)
+            RuleBuilder:Open()
+        end
+        UIDropDownMenu_AddButton(info)
+
+        -- Custom library entries
+        if library and library.profiles then
             for i, entry in ipairs(library.profiles) do
-                local info = UIDropDownMenu_CreateInfo()
-                info.text = entry.name or ("Profile " .. i)
-                info.checked = (i == activeIdx)
-                info.func = function()
+                local cinfo = UIDropDownMenu_CreateInfo()
+                cinfo.text = entry.name or ("Custom " .. i)
+                cinfo.checked = (_isCustomized and activeIdx == i)
+                cinfo.func = function()
                     CustomProfile.SetActiveIndex(profileId, i)
                     TrueShot.Engine:ActivateProfile(baseProfile.specID)
                     RuleBuilder:Open()
                 end
-                UIDropDownMenu_AddButton(info)
+                UIDropDownMenu_AddButton(cinfo)
             end
-        end)
+        end
+    end)
+
+    -- Set dropdown text
+    if _isCustomized and library and library.profiles and activeIdx and activeIdx > 0 then
         local activeName = library.profiles[activeIdx] and library.profiles[activeIdx].name or "Custom"
         UIDropDownMenu_SetText(_mainFrame._libDropdown, activeName)
     else
-        _mainFrame._libSelector:Hide()
-        -- Restore normal divider and left panel positions
-        _mainFrame._divider:ClearAllPoints()
-        _mainFrame._divider:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -34)
-        _mainFrame._divider:SetPoint("TOPRIGHT", _mainFrame, "TOPRIGHT", -8, -34)
-        _mainFrame._leftPanel:ClearAllPoints()
-        _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -38)
-        _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
+        UIDropDownMenu_SetText(_mainFrame._libDropdown, "Built-in: " .. (baseProfile.displayName or profileId))
     end
+
+    -- Only show Delete button when viewing a custom entry with 2+ entries
+    local libraryCount = library and library.profiles and #library.profiles or 0
+    _mainFrame._libDelBtn:SetShown(_isCustomized and libraryCount > 1)
 
     self:RefreshRuleList()
     self:UpdateButtonStates()

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -195,12 +195,41 @@ local function CreateMainFrame()
     divider:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -34)
     divider:SetPoint("TOPRIGHT", f, "TOPRIGHT", -8, -34)
     divider:SetColorTexture(0.3, 0.3, 0.3, 1)
+    f._divider = divider
+
+    -- Profile library selector (hidden by default, shown when 2+ profiles exist)
+    local libSelector = CreateFrame("Frame", nil, f)
+    libSelector:SetHeight(26)
+    libSelector:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -35)
+    libSelector:SetPoint("TOPRIGHT", f, "TOPRIGHT", -8, -35)
+    libSelector:Hide()
+    f._libSelector = libSelector
+
+    local libLabel = libSelector:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    libLabel:SetPoint("LEFT", libSelector, "LEFT", 4, 0)
+    libLabel:SetText("Active:")
+    f._libLabel = libLabel
+
+    local libDropdown = CreateFrame("Frame", "TrueShotRBLibDD", libSelector, "UIDropDownMenuTemplate")
+    libDropdown:SetPoint("LEFT", libLabel, "RIGHT", -8, -2)
+    UIDropDownMenu_SetWidth(libDropdown, 180)
+    f._libDropdown = libDropdown
+
+    local libDelBtn = CreateFrame("Button", nil, libSelector, "UIPanelButtonTemplate")
+    libDelBtn:SetSize(60, 20)
+    libDelBtn:SetPoint("RIGHT", libSelector, "RIGHT", -4, 0)
+    libDelBtn:SetText("Delete")
+    libDelBtn:SetScript("OnClick", function()
+        RuleBuilder:OnDeleteLibraryEntry()
+    end)
+    f._libDelBtn = libDelBtn
 
     -- Left panel (rule list)
     local leftPanel = CreateFrame("Frame", nil, f)
     leftPanel:SetPoint("TOPLEFT", f, "TOPLEFT", 8, -38)
     leftPanel:SetPoint("BOTTOMLEFT", f, "BOTTOMLEFT", 8, 44)
     leftPanel:SetWidth(LEFT_PANEL_WIDTH)
+    f._leftPanel = leftPanel
 
     local leftScroll = CreateFrame("ScrollFrame", "TrueShotRBLeftScroll", leftPanel, "UIPanelScrollFrameTemplate")
     leftScroll:SetPoint("TOPLEFT", leftPanel, "TOPLEFT", 0, 0)
@@ -641,6 +670,47 @@ function RuleBuilder:Open()
 
     _selectedIndex = nil
     _selectedVarIndex = nil
+
+    -- Profile library selector
+    local libraryCount = CustomProfile.GetLibraryCount and CustomProfile.GetLibraryCount(profileId) or 0
+    if _isCustomized and libraryCount > 1 then
+        _mainFrame._libSelector:Show()
+        -- Shift divider and left panel down to make room
+        _mainFrame._divider:ClearAllPoints()
+        _mainFrame._divider:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -60)
+        _mainFrame._divider:SetPoint("TOPRIGHT", _mainFrame, "TOPRIGHT", -8, -60)
+        _mainFrame._leftPanel:ClearAllPoints()
+        _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -64)
+        _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
+
+        local activeIdx = CustomProfile.GetActiveIndex(profileId)
+        local library = CustomProfile.GetProfileLibrary(profileId)
+        UIDropDownMenu_Initialize(_mainFrame._libDropdown, function()
+            for i, entry in ipairs(library.profiles) do
+                local info = UIDropDownMenu_CreateInfo()
+                info.text = entry.name or ("Profile " .. i)
+                info.checked = (i == activeIdx)
+                info.func = function()
+                    CustomProfile.SetActiveIndex(profileId, i)
+                    TrueShot.Engine:ActivateProfile(baseProfile.specID)
+                    RuleBuilder:Open()
+                end
+                UIDropDownMenu_AddButton(info)
+            end
+        end)
+        local activeName = library.profiles[activeIdx] and library.profiles[activeIdx].name or "Custom"
+        UIDropDownMenu_SetText(_mainFrame._libDropdown, activeName)
+    else
+        _mainFrame._libSelector:Hide()
+        -- Restore normal divider and left panel positions
+        _mainFrame._divider:ClearAllPoints()
+        _mainFrame._divider:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -34)
+        _mainFrame._divider:SetPoint("TOPRIGHT", _mainFrame, "TOPRIGHT", -8, -34)
+        _mainFrame._leftPanel:ClearAllPoints()
+        _mainFrame._leftPanel:SetPoint("TOPLEFT", _mainFrame, "TOPLEFT", 8, -38)
+        _mainFrame._leftPanel:SetPoint("BOTTOMLEFT", _mainFrame, "BOTTOMLEFT", 8, 44)
+    end
+
     self:RefreshRuleList()
     self:UpdateButtonStates()
     self:ClearRightPanel()
@@ -788,6 +858,19 @@ function RuleBuilder:OnReset()
     -- Refresh UI
     self:Open()
     print("|cff00ff00[TS]|r Reset to built-in profile.")
+end
+
+function RuleBuilder:OnDeleteLibraryEntry()
+    local Engine = TrueShot.Engine
+    local profile = Engine and Engine.activeProfile
+    if not profile then return end
+    local baseProfile = profile._baseProfile or profile
+    local profileId = baseProfile.id
+    local activeIdx = CustomProfile.GetActiveIndex(profileId)
+    CustomProfile.DeleteFromLibrary(profileId, activeIdx)
+    CustomProfile.InvalidateWrapper(profileId)
+    Engine:ActivateProfile(baseProfile.specID)
+    self:Open()
 end
 
 function RuleBuilder:SelectRule(index)

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -3,7 +3,6 @@
 TrueShot = TrueShot or {}
 
 local settingsCategory
-local subCategories = {}
 
 local function OpenRegisteredCategory()
     if not settingsCategory or not Settings or not Settings.OpenToCategory then return end
@@ -718,8 +717,7 @@ local function RegisterSettingsPanel()
 
     for _, tab in ipairs(tabs) do
         local panel = tab.factory()
-        local sub = Settings.RegisterCanvasLayoutSubcategory(settingsCategory, panel, tab.name)
-        subCategories[tab.name] = sub
+        Settings.RegisterCanvasLayoutSubcategory(settingsCategory, panel, tab.name)
     end
 end
 

--- a/SignalProbe.lua
+++ b/SignalProbe.lua
@@ -310,11 +310,6 @@ end
 -- Probe: aura read (validate actual aura data retrieval)
 ------------------------------------------------------------------------
 
-local AURA_TEST_SPELLS = {
-    { id = 272790, names = { "Frenzy", "Raserei" }, note = "Barbed Shot stacks" },
-    { id = 118455, names = { "Beast Cleave", "Bestiale Spaltung" }, note = "AoE buff" },
-    { id = 19574,  names = { "Bestial Wrath", "Zorn des Wildtiers" }, note = "Burst buff" },
-}
 
 function Probe:AuraRead()
     PrintHeader("aura read (all player buffs)")

--- a/TrueShot.toc
+++ b/TrueShot.toc
@@ -11,6 +11,7 @@
 ## OptionalDeps: Masque
 
 Engine.lua
+CustomProfile.lua
 Profiles/BM_DarkRanger.lua
 Profiles/BM_PackLeader.lua
 Profiles/MM_DarkRanger.lua
@@ -37,6 +38,5 @@ SettingsPanel.lua
 SignalProbe.lua
 CombatTrace.lua
 Scorecard.lua
-CustomProfile.lua
 ProfileIO.lua
 RuleBuilder.lua

--- a/TrueShot.toc
+++ b/TrueShot.toc
@@ -38,4 +38,5 @@ SignalProbe.lua
 CombatTrace.lua
 Scorecard.lua
 CustomProfile.lua
+ProfileIO.lua
 RuleBuilder.lua


### PR DESCRIPTION
## Summary

Share custom TrueShot profiles as copy-paste strings + manage multiple profiles per spec.

### Import/Export
- `/ts export` serializes the active custom profile as a `!TS1!<base64>` string
- `/ts import` pastes a string, validates it, previews it, and imports on confirm
- Export/Import buttons in the Rule Builder bottom bar
- Custom serializer with BNF grammar (no loadstring, no code execution)
- 4-phase validation: format, schema, semantic, warnings
- Strict security: depth-limited parsing, whitelist-based key filtering, condition type validation

### Profile Library
- Multiple custom profiles per spec with instant switching
- Import adds to library instead of overwriting existing profiles
- Profile selector dropdown in Rule Builder when 2+ profiles exist
- Delete individual profiles from the library
- Auto-migration from previous single-profile storage format
- "Reset to Built-in" wipes entire library

### Architecture

- `ProfileIO.lua` (~1184 LOC): Base64 codec, custom serializer/deserializer, 4-phase validation, export/import UI frames
- `CustomProfile.lua` (+124 LOC): Profile library storage model (array with activeIndex), migration, library API
- `RuleBuilder.lua` (+113 LOC): Library selector dropdown, export/import buttons
- TOC load order fix: CustomProfile.lua before profiles for condition schema registration

### Changes

- 6 files changed, +1449 lines

Closes #68

## Test plan

- [ ] `/ts export` shows error when no custom profile exists
- [ ] Customize a profile, `/ts export` produces a string
- [ ] Copy string, `/ts import`, paste, Preview shows correct summary
- [ ] Validation rejects malformed strings, wrong class profiles, bad structure
- [ ] Import adds to library (does not overwrite existing)
- [ ] Profile selector dropdown appears with 2+ profiles
- [ ] Switching profiles in dropdown re-activates immediately
- [ ] Delete button removes individual profile from library
- [ ] "Reset to Built-in" wipes entire library
- [ ] `/reload` preserves all library entries
- [ ] Round-trip: export -> import produces identical rules