### PR TITLE
Add configurable recommendation reason position (above or below icon)

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -19,6 +19,7 @@ local DEFAULTS = {
     showCooldownSwipe = true,
     showCastFeedback = true,
     showWhyOverlay = false,
+    showWhyAboveIcon = false,
     showPhaseIndicator = false,
     showOverrideIndicator = true,
     showKeybinds = true,

--- a/Display.lua
+++ b/Display.lua
@@ -1005,15 +1005,21 @@ function Display:UpdateContainerSize()
 
     reasonText:ClearAllPoints()
     phaseText:ClearAllPoints()
+    local showWhyAboveIcon = TrueShot.GetOpt("showWhyAboveIcon") and true or false
     if isVertical then
         reasonText:SetPoint("LEFT", container, "RIGHT", 4, -8)
         reasonText:SetJustifyH("LEFT")
         phaseText:SetPoint("LEFT", container, "RIGHT", 4, 8)
         phaseText:SetJustifyH("LEFT")
     else
-        reasonText:SetPoint("TOP", container, "BOTTOM", 0, -2)
+        if showWhyAboveIcon then
+            reasonText:SetPoint("BOTTOM", container, "TOP", 0, 2)
+            phaseText:SetPoint("BOTTOM", container, "TOP", 0, 14)
+        else
+            reasonText:SetPoint("TOP", container, "BOTTOM", 0, -2)
+            phaseText:SetPoint("BOTTOM", container, "TOP", 0, 2)
+        end
         reasonText:SetJustifyH("CENTER")
-        phaseText:SetPoint("BOTTOM", container, "TOP", 0, 2)
         phaseText:SetJustifyH("CENTER")
     end
 

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -308,10 +308,25 @@ local function CreateFeaturesPanel()
         rangeDesc, "showWhyOverlay"
     )
 
+    local whyPosCheck, whyPosDesc = CreateCheckbox(
+        panel, "Show reason above icon",
+        "When enabled, the recommendation reason is shown above the primary icon instead of below it.",
+        whyDesc, "showWhyAboveIcon"
+    )
+
+    local function SyncWhyPositionToggle()
+        local enabled = TrueShot.GetOpt("showWhyOverlay") and true or false
+        whyPosCheck:SetEnabled(enabled)
+        whyPosCheck.Text:SetTextColor(enabled and 1 or 0.5, enabled and 0.82 or 0.5, enabled and 0 or 0.5)
+        whyPosDesc:SetTextColor(enabled and 1 or 0.5, enabled and 1 or 0.5, enabled and 1 or 0.5)
+    end
+
+    whyCheck:HookScript("OnClick", SyncWhyPositionToggle)
+
     local aoeHintCheck, aoeHintDesc = CreateCheckbox(
         panel, "Show AoE hint icon",
         "Display a secondary icon below the primary icon when an AoE ability is recommended (e.g. Wild Thrash at 2+ targets).",
-        whyDesc, "showAoeHint"
+        whyPosDesc, "showAoeHint"
     )
 
     local glowCheck, glowDesc = CreateCheckbox(
@@ -343,6 +358,8 @@ local function CreateFeaturesPanel()
         keybindCheck.sync()
         rangeCheck.sync()
         whyCheck.sync()
+        whyPosCheck.sync()
+        SyncWhyPositionToggle()
         aoeHintCheck.sync()
         glowCheck.sync()
         scorecardCheck.sync()


### PR DESCRIPTION
## Description
This change keeps the existing "Show recommendation reason" feature and adds a dependent position toggle so users can choose where the reason text appears.

## What changed
1. Added a new option: `showWhyAboveIcon` (default `false`, preserving current behavior).
2. Added a new Features checkbox: "Show reason above icon".
3. Made the new checkbox dependent on "Show recommendation reason" (enabled only when that setting is on).
4. Updated display anchoring logic so recommendation reason can appear:
   - Below the primary icon (default/current behavior)
   - Above the primary icon (new behavior)
5. Added spacing logic to prevent overlap with phase text when both are above the icon.

## Behavior impact
- No behavior change for existing users unless they enable the new toggle.
- Recommendation reason remains below the icon by default.
