### PR TITLE
feat: abbreviate keybind text on icons

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -465,8 +465,14 @@ local function FormatKeybindForDisplay(key)
     key = key:gsub("ESCAPE", "Esc")
     key = key:gsub("SPACE", "Sp")
     key = key:gsub("ENTER", "Ent")
+    key = key:gsub("TAB", "Tab")
     key = key:gsub("CAPSLOCK", "CpLk")
     key = key:gsub("NUMLOCK", "NmLk")
+    -- Arrows
+    key = key:gsub("UP", "Up")
+    key = key:gsub("DOWN", "Dn")
+    key = key:gsub("LEFT", "Lt")
+    key = key:gsub("RIGHT", "Rt")
     return key
 end
 

--- a/Display.lua
+++ b/Display.lua
@@ -468,11 +468,15 @@ local function FormatKeybindForDisplay(key)
     key = key:gsub("TAB", "Tab")
     key = key:gsub("CAPSLOCK", "CpLk")
     key = key:gsub("NUMLOCK", "NmLk")
-    -- Arrows
-    key = key:gsub("UP", "Up")
-    key = key:gsub("DOWN", "Dn")
-    key = key:gsub("LEFT", "Lt")
-    key = key:gsub("RIGHT", "Rt")
+    -- Arrows (anchored to avoid mangling gamepad PADD* tokens)
+    key = key:gsub("^UP$", "Up")
+    key = key:gsub("%-UP$", "-Up")
+    key = key:gsub("^DOWN$", "Dn")
+    key = key:gsub("%-DOWN$", "-Dn")
+    key = key:gsub("^LEFT$", "Lt")
+    key = key:gsub("%-LEFT$", "-Lt")
+    key = key:gsub("^RIGHT$", "Rt")
+    key = key:gsub("%-RIGHT$", "-Rt")
     return key
 end
 

--- a/Display.lua
+++ b/Display.lua
@@ -438,9 +438,35 @@ local function FormatKeybindForDisplay(key)
     if type(key) ~= "string" then
         return ""
     end
+    -- Modifiers
     key = key:gsub("SHIFT%-", "S-")
     key = key:gsub("CTRL%-", "C-")
     key = key:gsub("ALT%-", "A-")
+    -- Numpad
+    key = key:gsub("NUMPAD(%d)", "N%1")
+    key = key:gsub("NUMPADDECIMAL", "N.")
+    key = key:gsub("NUMPADPLUS", "N+")
+    key = key:gsub("NUMPADMINUS", "N-")
+    key = key:gsub("NUMPADMULTIPLY", "N*")
+    key = key:gsub("NUMPADDIVIDE", "N/")
+    -- Mouse
+    key = key:gsub("MOUSEWHEELUP", "MWU")
+    key = key:gsub("MOUSEWHEELDOWN", "MWD")
+    key = key:gsub("MIDDLEBUTTON", "M3")
+    key = key:gsub("BUTTON(%d+)", "M%1")
+    -- Navigation
+    key = key:gsub("PAGEUP", "PgU")
+    key = key:gsub("PAGEDOWN", "PgD")
+    key = key:gsub("INSERT", "Ins")
+    key = key:gsub("DELETE", "Del")
+    key = key:gsub("HOME", "Hm")
+    -- Common keys
+    key = key:gsub("BACKSPACE", "BkSp")
+    key = key:gsub("ESCAPE", "Esc")
+    key = key:gsub("SPACE", "Sp")
+    key = key:gsub("ENTER", "Ent")
+    key = key:gsub("CAPSLOCK", "CpLk")
+    key = key:gsub("NUMLOCK", "NmLk")
     return key
 end
 


### PR DESCRIPTION
## Summary
- Extend `FormatKeybindForDisplay()` to shorten all common WoW keybind names
- Numpad: `NUMPAD1` -> `N1`, `NUMPADDECIMAL` -> `N.`, operators -> `N+`, `N-`, `N*`, `N/`
- Mouse: `BUTTON4` -> `M4`, `MIDDLEBUTTON` -> `M3`, `MOUSEWHEELUP` -> `MWU`
- Navigation: `PAGEUP` -> `PgU`, `INSERT` -> `Ins`, `DELETE` -> `Del`, `HOME` -> `Hm`
- Common: `SPACE` -> `Sp`, `ESCAPE` -> `Esc`, `ENTER` -> `Ent`, `BACKSPACE` -> `BkSp`, `TAB` -> `Tab`
- Arrows: `UP` -> `Up`, `DOWN` -> `Dn`, `LEFT` -> `Lt`, `RIGHT` -> `Rt` (anchored to avoid mangling gamepad PADD* tokens)

Closes #79

## Test plan
- [ ] Keybind text on icons is shorter and more readable
- [ ] Numpad-bound abilities show N1, N2 etc. instead of NUMPAD1
- [ ] Modifier combos display correctly (e.g. S-N1 for SHIFT-NUMPAD1)
- [ ] Gamepad PADD* bindings are not affected
- [ ] Existing SHIFT/CTRL/ALT abbreviations unchanged