### PR TITLE
Fix hunter readiness gates and survival spell routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.23.0 - 2026-04-12
+
+### Added
+- **Assisted Combat suggestion gate**: New `ac_suggested` engine condition allows profiles and custom rules to key off Blizzard's live recommendation surface instead of direct spell-usable checks.
+- **Phase and queue layout controls**: Settings wiring now exposes the phase indicator plus queue icon count, size, and spacing options in the live UI.
+
+### Changed
+- **Hunter-first scope**: README and project goals now define Hunter as the current shipping target, while other classes remain foundation/alpha support.
+- **MM/SV readiness rules**: Marksmanship and Survival cooldown-sensitive overrides now follow Assisted Combat suggestions instead of direct `IsSpellUsable()` readiness checks.
+- **SV Sentinel Wildfire Bomb handling**: Charge-cap logic now relies only on validated charge-count signals.
+
+### Fixed
+- **Enemy-target-only visibility**: Overlay visibility now matches the setting text while preserving the documented combat fallback.
+- **Survival spell routing**: Removed the old Hatchet Toss blacklist path that could suppress `Kill Command` through a shared spell ID in melee.
+- **BM Pack Leader debug output**: Bestial Wrath cooldown debug text now reflects the actual configured cooldown.
+
 ## v0.20.0 - 2026-04-09
 
 ### Added

--- a/CustomProfile.lua
+++ b/CustomProfile.lua
@@ -47,6 +47,8 @@ end
 ------------------------------------------------------------------------
 
 CustomProfile.RegisterConditionSchema("_engine", {
+    { id = "ac_suggested",    label = "Assisted Combat Suggests Spell",
+      params = { { field = "spellID", fieldType = "spell", label = "Spell" } } },
     { id = "spell_glowing",   label = "Spell Proc Active",
       params = { { field = "spellID", fieldType = "spell", label = "Spell" } } },
     { id = "target_count",    label = "Target Count",

--- a/Engine.lua
+++ b/Engine.lua
@@ -100,6 +100,54 @@ function Engine:IsSpellGlowing(spellID)
 end
 
 ------------------------------------------------------------------------
+-- Assisted Combat suggestion cache
+------------------------------------------------------------------------
+
+local _acSuggestionTick = 0
+local _acPrimarySpell = nil
+local _acSuggestedSpells = {}
+
+local function RefreshACSuggestions()
+    local now = GetTime()
+    if _acSuggestionTick == now then return end
+
+    _acSuggestionTick = now
+    _acPrimarySpell = nil
+    wipe(_acSuggestedSpells)
+
+    if not C_AssistedCombat or not C_AssistedCombat.IsAvailable() then
+        return
+    end
+
+    local baseSpell = C_AssistedCombat.GetNextCastSpell()
+    if baseSpell and not IsSecret(baseSpell) then
+        _acPrimarySpell = baseSpell
+        _acSuggestedSpells[baseSpell] = true
+    end
+
+    local rotSpells = C_AssistedCombat.GetRotationSpells()
+    if not rotSpells or IsSecret(rotSpells) then
+        return
+    end
+
+    for _, entry in ipairs(rotSpells) do
+        local spellID = entry
+        if type(entry) == "table" then
+            spellID = entry.spellID or entry[1]
+        end
+        if spellID and not IsSecret(spellID) then
+            _acSuggestedSpells[spellID] = true
+        end
+    end
+end
+
+function Engine:IsSpellSuggestedByAC(spellID)
+    if not spellID then return false end
+    RefreshACSuggestions()
+    return _acSuggestedSpells[spellID] == true
+end
+
+------------------------------------------------------------------------
 -- Condition evaluator (generic conditions only)
 ------------------------------------------------------------------------
 
@@ -128,6 +176,9 @@ function Engine:EvalCondition(cond)
 
     elseif cond.type == "spell_glowing" then
         return self:IsSpellGlowing(cond.spellID)
+
+    elseif cond.type == "ac_suggested" then
+        return self:IsSpellSuggestedByAC(cond.spellID)
 
     elseif cond.type == "target_count" then
         local count = GetHostileCount()
@@ -249,7 +300,8 @@ function Engine:ComputeQueue(iconCount)
         return queue
     end
 
-    local baseSpell = C_AssistedCombat.GetNextCastSpell()
+    RefreshACSuggestions()
+    local baseSpell = _acPrimarySpell
 
     -- Build conditional blacklist for this frame
     wipe(_condBlacklist)

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -164,7 +164,7 @@ function Profile:GetDebugLines()
     local bwElapsed = s.lastBWCast > 0 and (GetTime() - s.lastBWCast) or 0
     return {
         "  BW CD: " .. (s.lastBWCast > 0
-            and string.format("%.1fs elapsed (est ~%ds)", bwElapsed, 60)
+            and string.format("%.1fs elapsed (est ~%ds)", bwElapsed, BW_COOLDOWN)
             or "not cast yet"),
         "  Last cast was KC: " .. tostring(s.lastCastWasKC),
     }

--- a/Profiles/MM_DarkRanger.lua
+++ b/Profiles/MM_DarkRanger.lua
@@ -123,7 +123,7 @@ local Profile = {
             reason = "Post-RF Window",
             condition = {
                 type = "and",
-                left  = { type = "trueshot_ready" },
+                left  = { type = "ac_suggested", spellID = SPELLS.Trueshot },
                 right = {
                     type = "and",
                     left  = { type = "rapid_fire_recent", seconds = 3 },
@@ -223,13 +223,6 @@ function Profile:EvalCondition(cond)
     elseif cond.type == "wa_available" then
         return s.wailingArrowAvailable
 
-    elseif cond.type == "trueshot_ready" then
-        if C_Spell and C_Spell.IsSpellUsable then
-            local ok, usable = pcall(C_Spell.IsSpellUsable, SPELLS.Trueshot)
-            if ok then return usable end
-        end
-        return false
-
     elseif cond.type == "trueshot_just_cast" then
         local threshold = cond.seconds or 2
         return s.lastTrueshotCast > 0 and (now - s.lastTrueshotCast) <= threshold
@@ -299,7 +292,6 @@ if TrueShot.CustomProfile then
         { id = "ba_ready",          label = "Black Arrow Ready",       params = {} },
         { id = "in_withering_fire", label = "In Withering Fire",       params = {} },
         { id = "wa_available",      label = "Wailing Arrow Available", params = {} },
-        { id = "trueshot_ready",    label = "Trueshot Ready",          params = {} },
         { id = "trueshot_just_cast", label = "Trueshot Just Cast",
           params = { { field = "seconds", fieldType = "number", default = 2, label = "Seconds window" } } },
         { id = "trueshot_active",   label = "Trueshot Active",         params = {} },

--- a/Profiles/MM_Sentinel.lua
+++ b/Profiles/MM_Sentinel.lua
@@ -86,7 +86,7 @@ local Profile = {
             reason = "Post-RF Window",
             condition = {
                 type = "and",
-                left  = { type = "trueshot_ready" },
+                left  = { type = "ac_suggested", spellID = SPELLS.Trueshot },
                 right = {
                     type = "and",
                     left  = { type = "rapid_fire_recent", seconds = 3 },
@@ -109,7 +109,7 @@ local Profile = {
             reason = "Chakram",
             condition = {
                 type = "and",
-                left  = { type = "chakram_ready" },
+                left  = { type = "ac_suggested", spellID = SPELLS.MoonlightChakram },
                 right = {
                     type = "and",
                     left  = { type = "trueshot_active" },
@@ -159,14 +159,7 @@ function Profile:EvalCondition(cond)
     local s = self.state
     local now = GetTime()
 
-    if cond.type == "trueshot_ready" then
-        if C_Spell and C_Spell.IsSpellUsable then
-            local ok, usable = pcall(C_Spell.IsSpellUsable, SPELLS.Trueshot)
-            if ok then return usable end
-        end
-        return false
-
-    elseif cond.type == "trueshot_just_cast" then
+    if cond.type == "trueshot_just_cast" then
         local threshold = cond.seconds or 2
         return s.lastTrueshotCast > 0 and (now - s.lastTrueshotCast) <= threshold
 
@@ -180,13 +173,6 @@ function Profile:EvalCondition(cond)
     elseif cond.type == "volley_recent" then
         local threshold = cond.seconds or 2
         return s.lastVolleyCast > 0 and (now - s.lastVolleyCast) <= threshold
-
-    elseif cond.type == "chakram_ready" then
-        if C_Spell and C_Spell.IsSpellUsable then
-            local ok, usable = pcall(C_Spell.IsSpellUsable, SPELLS.MoonlightChakram)
-            if ok then return usable end
-        end
-        return false
 
     elseif cond.type == "aimed_shot_ready" then
         if C_Spell and C_Spell.GetSpellCharges then
@@ -244,7 +230,6 @@ Engine:RegisterProfile(Profile)
 
 if TrueShot.CustomProfile then
     TrueShot.CustomProfile.RegisterConditionSchema("Hunter.MM.Sentinel", {
-        { id = "trueshot_ready",    label = "Trueshot Ready",    params = {} },
         { id = "trueshot_just_cast", label = "Trueshot Just Cast",
           params = { { field = "seconds", fieldType = "number", default = 2, label = "Seconds window" } } },
         { id = "trueshot_active",   label = "Trueshot Active",   params = {} },
@@ -252,7 +237,6 @@ if TrueShot.CustomProfile then
           params = { { field = "seconds", fieldType = "number", default = 3, label = "Seconds window" } } },
         { id = "volley_recent",     label = "Volley Recent",
           params = { { field = "seconds", fieldType = "number", default = 2, label = "Seconds window" } } },
-        { id = "chakram_ready",     label = "Moonlight Chakram Ready", params = {} },
         { id = "aimed_shot_ready",  label = "Aimed Shot Ready",  params = {} },
     })
 end

--- a/Profiles/SV_PackLeader.lua
+++ b/Profiles/SV_PackLeader.lua
@@ -17,15 +17,10 @@ local SPELLS = {
     Takedown       = 1250646,
     Boomstick      = 1261193,
     FlamefangPitch = 1251592,
-    RaptorStrike   = 186270,
     Harpoon        = 190925,
-    HatchetToss    = 259489,
     CallPet1       = 883,
     RevivePet      = 982,
 }
-
--- Melee range probe spells (if any returns in_range=true, player is in melee)
-local MELEE_PROBE_SPELLS = { SPELLS.RaptorStrike }
 
 ------------------------------------------------------------------------
 -- Profile definition
@@ -60,13 +55,6 @@ local Profile = {
         { type = "BLACKLIST", spellID = SPELLS.Harpoon },
         { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
         { type = "BLACKLIST", spellID = SPELLS.RevivePet },
-
-        -- Hatchet Toss: suppress when in melee range
-        {
-            type = "BLACKLIST_CONDITIONAL",
-            spellID = SPELLS.HatchetToss,
-            condition = { type = "in_melee_range" },
-        },
 
         -- Stampede: first KC after Takedown triggers Stampede
         {
@@ -105,7 +93,7 @@ local Profile = {
             type = "PREFER",
             spellID = SPELLS.FlamefangPitch,
             reason = "Flamefang",
-            condition = { type = "flamefang_ready" },
+            condition = { type = "ac_suggested", spellID = SPELLS.FlamefangPitch },
         },
     },
 }
@@ -169,16 +157,6 @@ function Profile:EvalCondition(cond)
         if s.lastBoomstickCast == 0 then return false end
         return (now - s.lastBoomstickCast) < BOOMSTICK_COOLDOWN
 
-    elseif cond.type == "in_melee_range" then
-        -- Check if any melee probe spell is in range; fallback: false (don't suppress)
-        if not C_Spell or not C_Spell.IsSpellInRange then return false end
-        if not UnitExists("target") then return false end
-        for _, probeID in ipairs(MELEE_PROBE_SPELLS) do
-            local ok, inRange = pcall(C_Spell.IsSpellInRange, probeID, "target")
-            if ok and inRange == true then return true end
-        end
-        return false
-
     elseif cond.type == "wfb_charges" then
         if C_Spell and C_Spell.GetSpellCharges then
             local ok, info = pcall(C_Spell.GetSpellCharges, SPELLS.WildfireBomb)
@@ -195,13 +173,6 @@ function Profile:EvalCondition(cond)
                 elseif op == "<"  then return info.currentCharges < val
                 end
             end
-        end
-        return false
-
-    elseif cond.type == "flamefang_ready" then
-        if C_Spell and C_Spell.IsSpellUsable then
-            local ok, usable = pcall(C_Spell.IsSpellUsable, SPELLS.FlamefangPitch)
-            if ok then return usable end
         end
         return false
     end
@@ -260,12 +231,10 @@ if TrueShot.CustomProfile then
         { id = "takedown_active",    label = "Takedown Active",          params = {} },
         { id = "kc_cast_in_takedown", label = "KC Cast In Takedown",     params = {} },
         { id = "boomstick_on_cd",    label = "Boomstick On Cooldown",    params = {} },
-        { id = "in_melee_range",     label = "In Melee Range",           params = {} },
         { id = "wfb_charges",        label = "Wildfire Bomb Charges",
           params = {
               { field = "op",    fieldType = "string", default = "==", label = "Operator" },
               { field = "value", fieldType = "number", default = 2,    label = "Charge count" },
           } },
-        { id = "flamefang_ready",    label = "Flamefang Pitch Ready",    params = {} },
     })
 end

--- a/Profiles/SV_Sentinel.lua
+++ b/Profiles/SV_Sentinel.lua
@@ -18,13 +18,9 @@ local SPELLS = {
     MoonlightChakram = 1264902,
     FlamefangPitch   = 1251592,
     Harpoon          = 190925,
-    HatchetToss      = 259489,
-    RaptorStrike     = 186270,
     CallPet1         = 883,
     RevivePet        = 982,
 }
-
-local MELEE_PROBE_SPELLS = { SPELLS.RaptorStrike }
 
 ------------------------------------------------------------------------
 -- Profile definition
@@ -60,19 +56,12 @@ local Profile = {
         { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
         { type = "BLACKLIST", spellID = SPELLS.RevivePet },
 
-        -- Hatchet Toss: suppress when in melee range
-        {
-            type = "BLACKLIST_CONDITIONAL",
-            spellID = SPELLS.HatchetToss,
-            condition = { type = "in_melee_range" },
-        },
-
         -- Prevent capping WFB charges while fishing Sentinel's Mark procs
         {
             type = "PREFER",
             spellID = SPELLS.WildfireBomb,
             reason = "Charge Cap",
-            condition = { type = "wfb_near_cap", seconds = 5 },
+            condition = { type = "spell_charges", spellID = SPELLS.WildfireBomb, op = ">=", value = 2 },
         },
 
         -- Boomstick pinned during Takedown burst (suppress when on CD)
@@ -104,7 +93,7 @@ local Profile = {
             type = "PREFER",
             spellID = SPELLS.FlamefangPitch,
             reason = "Flamefang",
-            condition = { type = "flamefang_ready" },
+            condition = { type = "ac_suggested", spellID = SPELLS.FlamefangPitch },
         },
     },
 }
@@ -156,45 +145,6 @@ function Profile:EvalCondition(cond)
         if s.lastBoomstickCast == 0 then return false end
         return (now - s.lastBoomstickCast) < BOOMSTICK_COOLDOWN
 
-    elseif cond.type == "in_melee_range" then
-        if not C_Spell or not C_Spell.IsSpellInRange then return false end
-        if not UnitExists("target") then return false end
-        for _, probeID in ipairs(MELEE_PROBE_SPELLS) do
-            local ok, inRange = pcall(C_Spell.IsSpellInRange, probeID, "target")
-            if ok and inRange == true then return true end
-        end
-        return false
-
-    elseif cond.type == "wfb_near_cap" then
-        if C_Spell and C_Spell.GetSpellCharges then
-            local ok, info = pcall(C_Spell.GetSpellCharges, SPELLS.WildfireBomb)
-            if ok and info and info.currentCharges then
-                if issecretvalue and issecretvalue(info.currentCharges) then
-                    return false
-                end
-                if info.currentCharges >= 2 then return true end
-                if info.currentCharges == 1 then
-                    local startTime = info.cooldownStartTime
-                    local duration = info.cooldownDuration
-                    if not startTime or not duration then return false end
-                    if issecretvalue and (issecretvalue(startTime) or issecretvalue(duration)) then
-                        return false
-                    end
-                    local threshold = cond.seconds or 5
-                    local timeToRecharge = (startTime + duration) - now
-                    return timeToRecharge <= threshold
-                end
-                return false
-            end
-        end
-        return false
-
-    elseif cond.type == "flamefang_ready" then
-        if C_Spell and C_Spell.IsSpellUsable then
-            local ok, usable = pcall(C_Spell.IsSpellUsable, SPELLS.FlamefangPitch)
-            if ok then return usable end
-        end
-        return false
     end
 
     return nil
@@ -214,12 +164,7 @@ function Profile:GetDebugLines()
         local ok, info = pcall(C_Spell.GetSpellCharges, SPELLS.WildfireBomb)
         if ok and info and info.currentCharges then
             if not (issecretvalue and issecretvalue(info.currentCharges)) then
-                local timeToCap = ""
-                if info.currentCharges < info.maxCharges then
-                    local rechargeIn = (info.cooldownStartTime + info.cooldownDuration) - now
-                    timeToCap = string.format(", %.1fs to next", rechargeIn)
-                end
-                wfbLine = string.format("%d/%d%s", info.currentCharges, info.maxCharges, timeToCap)
+                wfbLine = string.format("%d/%d", info.currentCharges, info.maxCharges)
             end
         end
     end
@@ -256,9 +201,5 @@ if TrueShot.CustomProfile then
           params = { { field = "seconds", fieldType = "number", default = 5, label = "Seconds window" } } },
         { id = "takedown_active",   label = "Takedown Active",           params = {} },
         { id = "boomstick_on_cd",   label = "Boomstick On Cooldown",     params = {} },
-        { id = "in_melee_range",    label = "In Melee Range",            params = {} },
-        { id = "wfb_near_cap",      label = "Wildfire Bomb Near Cap",
-          params = { { field = "seconds", fieldType = "number", default = 5, label = "Seconds to recharge" } } },
-        { id = "flamefang_ready",   label = "Flamefang Pitch Ready",     params = {} },
     })
 end

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Blizzard's built-in rotation helper gets you started, but it has gaps: wrong AoE
 
 ## Supported Classes
 
-### Hunter (Primary)
+### Hunter (Primary Shipping Target)
 
-TrueShot is built for Hunters. All three specs are fully validated in-game with WCL-backed rotation analysis and detailed cast-event state machines.
+TrueShot is built for Hunters first. Hunter is the class that should deliver clear practical value today, and all three specs are the standard the addon should be judged against.
 
 | Spec | Hero Path | Key Overrides |
 |------|-----------|---------------|
@@ -20,12 +20,14 @@ TrueShot is built for Hunters. All three specs are fully validated in-game with 
 | **Beast Mastery** | Pack Leader | Nature's Ally KC weaving, Wild Thrash AoE hint, Bestial Wrath timing |
 | **Marksmanship** | Dark Ranger | Trueshot opener sequence, Volley/Trueshot anti-overlap, Withering Fire BA priority |
 | **Marksmanship** | Sentinel | Post-Rapid Fire Trueshot gating, Volley anti-overlap, Moonlight Chakram filler timing |
-| **Survival** | Pack Leader | Stampede KC sequencing, Boomstick CD tracking, Takedown burst window, Hatchet Toss melee gating |
-| **Survival** | Sentinel | WFB charge management, Boomstick CD tracking, Moonlight Chakram timing, Hatchet Toss melee gating |
+| **Survival** | Pack Leader | Stampede KC sequencing, Boomstick CD tracking, Takedown burst window, Flamefang timing |
+| **Survival** | Sentinel | WFB charge-cap spend, Boomstick CD tracking, Moonlight Chakram timing, Flamefang timing |
 
-### Demon Hunter, Druid, Mage (Alpha)
+### Demon Hunter, Druid, Mage (Foundation / Alpha)
 
-These classes have profile support with burst window tracking and hero path auto-detection. However, we don't play these classes ourselves and rely on community feedback for validation.
+These classes exist as framework groundwork and early profile lanes. They are useful for proving that the architecture can grow beyond Hunter, but they are not the main product promise yet.
+
+We currently treat them as opportunistic expansion paths: they can improve over time, especially when they become classes we actively play ourselves, but Hunter polish comes first.
 
 **If you play one of these classes and notice something off or want to suggest changes, please [open an issue](https://github.com/itsDNNS/TrueShot/issues).**
 
@@ -35,7 +37,7 @@ These classes have profile support with burst window tracking and hero path auto
 | **Druid** | Feral, Balance | 4 | Tiger's Fury/Berserk and Celestial Alignment burst tracking. Resource-dependent (Energy, Astral Power) limits overrides. |
 | **Mage** | Fire, Frost, Arcane | 6 | Combustion, Frozen Orb, Arcane Surge burst windows. Frost shatter combo (Flurry > Ice Lance). |
 
-All 20 profiles across 4 classes support automatic hero path detection via `IsPlayerSpell` markers.
+All 20 profiles across 4 classes support automatic hero path detection via `IsPlayerSpell` markers, but only Hunter should currently be read as fully productized support.
 
 ## How It Works
 

--- a/docs/API_CONSTRAINTS.md
+++ b/docs/API_CONSTRAINTS.md
@@ -112,6 +112,7 @@ These are acceptable:
 
 - "Spell X was cast by the player, so start a local timer."
 - "Spell Y unlocks Spell Z, so mark Z as available until consumed."
+- "Assisted Combat currently surfaces Spell X in its primary or rotation suggestions, so use that as a legal readiness gate for an override."
 - "The target is casting, so interrupt can be surfaced."
 - "Nameplate count is at least N, so prefer an AoE branch."
 

--- a/docs/PROJECT_GOALS.md
+++ b/docs/PROJECT_GOALS.md
@@ -4,16 +4,31 @@
 
 ## Primary Goal
 
-Build a hunter-focused recommendation framework for Retail `Midnight` that is:
+Build a hunter-first recommendation framework for Retail `Midnight` that is:
 
 - lightweight
 - performant on the live client
 - honest about API limits
-- still functionally useful enough that players can rely on it as a real rotational aid
+- functionally strong enough that Hunter players can rely on it as a real rotational aid
+- reusable enough that additional classes can be added later without re-architecting the addon
 
 In short:
 
-`TrueShot` should aim for the highest practical gameplay value per unit of client overhead.
+`TrueShot` should aim for the highest practical Hunter gameplay value per unit of client overhead, while laying clean groundwork for later class expansion.
+
+## Scope Priority
+
+Current shipping priority is explicit:
+
+1. Hunter should be the first class supported to a genuinely complete, high-value standard.
+2. Other classes may exist as groundwork or personal expansion lanes, but they must not dilute Hunter polish.
+3. New class work should become a real product priority only when there is a practical reason to invest in it, for example because the maintainer actively plays that class.
+
+Today that means:
+
+- Hunter quality is the bar the addon should be judged against
+- multi-class architecture is a feature, but not the current promise
+- future expansion can follow naturally, with `Demon Hunter` as an obvious next candidate if it becomes an active play focus
 
 ## Product Principles
 
@@ -38,7 +53,7 @@ The goal is to stay lightweight **while still delivering the full practical func
 That means `TrueShot` should still try to provide:
 
 - a reliable recommendation queue
-- spec-aware profile behavior where signals are legal and validated
+- spec-aware Hunter behavior where signals are legal and validated
 - configurable, understandable overrides
 - useful debug visibility
 - graceful fallback behavior when a signal is unavailable
@@ -73,6 +88,7 @@ These goals imply a few concrete defaults:
 
 - engine work should bias toward shared, reusable, low-overhead logic
 - profiles should own narrowly scoped, validated rule/state logic
+- Hunter-facing work should outrank speculative breadth across other classes
 - UI should stay compact and cheap instead of becoming a heavyweight configuration surface
 - new features should justify both their gameplay value and their runtime cost
 - probe work and signal validation should happen before adding expensive or speculative behavior


### PR DESCRIPTION
## Summary
- replace MM/SV cooldown-sensitive readiness gates with Assisted Combat suggestion checks
- remove the unsafe Survival Hatchet Toss blacklist path that shared Kill Command's spell ID
- tighten Survival Wildfire Bomb charge logic to validated signals and align Hunter docs/debug output

## Why
The previous MM/SV rules depended on `IsSpellUsable()` for timing-sensitive overrides, and Survival could suppress `Kill Command` by treating spell ID `259489` as `Hatchet Toss` in melee. This keeps Hunter overrides aligned with the 12.0 signal model and removes a bad spell routing path.

## Validation
- `luac -p Engine.lua CustomProfile.lua Profiles/BM_PackLeader.lua Profiles/MM_DarkRanger.lua Profiles/MM_Sentinel.lua Profiles/SV_PackLeader.lua Profiles/SV_Sentinel.lua`
- `git diff --check`

## Follow-up
- in-game validation still needed for MM/SV suggestion timing
