### PR TITLE
v0.24.0: Hunter 1.0 source-citation pass + BM Pack Leader Stampede rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.24.0 - 2026-04-18
+
+### Added
+- **BM Pack Leader Stampede rule**: First `Kill Command` after `Bestial Wrath` is now pinned as `reason = "Stampede"`. The flag arms on `Bestial Wrath` cast, clears on the next `Kill Command`, and resets on combat end. Sourced to Azortharion, Icy Veins BM Hunter Rotation, guide updated 2026-04-10: "Activate Bestial Wrath. Once activated, your next Kill Command will spawn a Stampede."
+- **Hunter profile source citations**: Every Hunter profile file (BM DR, BM PL, MM DR, MM Sentinel, SV PL, SV Sentinel) now carries a structured header block with primary source URL, guide-update date, verified-on date, patch, and cross-check references (SimC midnight branch + Wowhead). Rotational rules carry inline `[src §<section> #N]` tags pointing at the priority step they implement; utility blacklists (pet / counter-shot / harpoon) are grouped without per-rule tags.
+- **Hunter logic test suite** (`tests/test_hunter_profiles.lua`): 30 scenario tests covering cast-event state machines and `EvalCondition` behavior for all six Hunter profiles, including the new Stampede arming/consumption path, the Nature's Ally anti-repeat guarantee, and a structural-ordering guard that the Stampede PIN precedes the KC Proc PIN in the rules array (first-match-wins in `Engine:ComputeQueue`).
+
+### Changed
+- **BM/MM/SV rotation reference docs**: Each now carries an explicit `Sources` table with tier (primary / cross-check / supplementary), URL, and stamp (guide-update date + patch). `Last reviewed: 2026-04-18` is recorded at the top of each doc.
+- **HUNTER_VALIDATION_MATRIX.md**: Expanded with a "Non-Hunter Isolation" section that documents the mechanical guarantee (specID routing in `Engine:ActivateProfile`) that foundation profiles cannot affect Hunter loading. BM Pack Leader validation now lists the Stampede PIN as a new live-check item.
+
 ## v0.23.7 - 2026-04-15
 
 ### Changed

--- a/Profiles/BM_DarkRanger.lua
+++ b/Profiles/BM_DarkRanger.lua
@@ -1,5 +1,25 @@
--- TrueShot Profile: Beast Mastery / Dark Ranger (Spec 253)
--- Cast-event state machine for Black Arrow, Bestial Wrath, Wailing Arrow
+-- TrueShot Profile: Beast Mastery / Dark Ranger (specID 253)
+-- Hero path: Dark Ranger (marker: Black Arrow 466930 via IsPlayerSpell)
+-- Cast-event state machine for Black Arrow, Bestial Wrath, Wailing Arrow.
+--
+-- PRIMARY SOURCE
+--   Author:        Azortharion
+--   Guide:         Beast Mastery Hunter DPS Rotation, Cooldowns, and Abilities - Midnight Season 1
+--   URL:           https://www.icy-veins.com/wow/beast-mastery-hunter-pve-dps-rotation-cooldowns-abilities
+--   Guide updated: 2026-04-10
+--   Verified:      2026-04-18
+--   Patch:         12.0.4 (Midnight Season 1)
+--
+-- CROSS-CHECK SOURCES
+--   SimC midnight branch: ActionPriorityLists/default/hunter_beast_mastery.simc
+--   Wowhead:              https://www.wowhead.com/guide/classes/hunter/beast-mastery/rotation-cooldowns-pve-dps
+--                         (Tarlo, Patch 12.0.1, updated 2026-03-21)
+--
+-- DESIGN SCOPE
+--   Overlay profile on Blizzard Assisted Combat.
+--   Dark Ranger is the Withering-Fire/Black-Arrow lane; the rules below focus on
+--   the BA-inside-WF window, WA-tail-of-WF, and Nature's Ally weaving.
+--   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
 
 local Engine = TrueShot.Engine
 
@@ -55,22 +75,25 @@ local Profile = {
     },
 
     rules = {
-        -- Filter utility spells
+        -- Filter utility spells (never part of the damage rotation).
         { type = "BLACKLIST", spellID = 883 },    -- Call Pet 1
         { type = "BLACKLIST", spellID = 982 },    -- Revive Pet
         { type = "BLACKLIST", spellID = 147362 }, -- Counter Shot (user preference)
 
-        -- Bestial Wrath: suppress only when on CD
-        -- Guide: dump BS charges before BW, hold a KC charge to enter with 2
+        -- [src §ST #2] "Bestial Wrath (use all Barbed Shot charges first)" -
+        -- shipped rule leaves BW available unless on CD. The BS-charge gate was
+        -- removed in v0.9.0 after a WCL cross-check showed top parses press BW
+        -- immediately; Azortharion 2026-04-10 text still recommends the dump,
+        -- so this stays a LIVE-verification follow-up, not a mechanical rule.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 19574,
             condition = { type = "bw_on_cd" },
         },
 
-        -- During Withering Fire: Black Arrow is highest DPS priority
-        -- (WF window is only 10s - missing a BA cast is a bigger loss than
-        -- delaying a KC proc by one GCD, since the glow persists)
+        -- [src §ST #4] "Black Arrow during Withering Fire" - WF is only 10s;
+        -- the guide explicitly ranks BA-in-WF above KC-proc for the burst window
+        -- since the glow persists across the GCD but the WF cast budget does not.
         {
             type = "PIN",
             spellID = 466930, -- Black Arrow
@@ -82,8 +105,11 @@ local Profile = {
             },
         },
 
-        -- Buffed Kill Command: prio 1 outside Withering Fire when proc glow active
-        -- (Alpha Predator / Call of the Wild) - during WF, BA stays higher
+        -- [src §ST #3] "Kill Command on cooldown with Nature's Ally up" - the KC
+        -- proc glow (Alpha Predator / Call of the Wild) is a direct non-secret
+        -- signal that AC does not always prioritise on position 1. Outside WF,
+        -- promote the proc via PIN; inside WF, BA stays higher so it is only
+        -- PREFER (see below).
         {
             type = "PIN",
             spellID = 34026, -- Kill Command
@@ -99,7 +125,8 @@ local Profile = {
             },
         },
 
-        -- Buffed KC during Withering Fire: still high prio, but after BA
+        -- [src §ST #3 inside WF] Buffed KC during Withering Fire: still high
+        -- priority, but PREFER-only so BA-in-WF stays pinned.
         {
             type = "PREFER",
             spellID = 34026, -- Kill Command
@@ -115,7 +142,9 @@ local Profile = {
             },
         },
 
-        -- Wailing Arrow near end of Withering Fire (~7s left on BW = ~2.5s left on WF)
+        -- [src §ST #5] "Wailing Arrow when 7 seconds remain on Bestial Wrath" -
+        -- WF ends ~5s before BW, so "7s on BW" maps to ~2.5s remaining on WF.
+        -- The WA tail fires a free BA, keeping the BA chain inside the WF window.
         {
             type = "PREFER",
             spellID = 392060, -- Wailing Arrow
@@ -127,7 +156,8 @@ local Profile = {
             },
         },
 
-        -- Outside Withering Fire: prefer Black Arrow when ready
+        -- [src §ST #8] "Black Arrow" as a lower-priority filler outside WF.
+        -- PREFER (not PIN) so AC still wins if it already surfaces BA.
         {
             type = "PREFER",
             spellID = 466930, -- Black Arrow
@@ -139,16 +169,24 @@ local Profile = {
             },
         },
 
-        -- Nature's Ally: never Kill Command twice in a row
+        -- [src §ST "Nature's Ally"] "Never cast Kill Command twice in a row."
+        -- Wild Thrash is NOT a valid Nature's Ally filler - the state machine
+        -- preserves last_cast_was_kc across WT casts.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 34026,
             condition = { type = "last_cast_was_kc" },
         },
 
-        -- Focus pooling: suppress Cobra Shot when Focus is too low for KC after,
-        -- but only when KC is actually castable (avoids blank icons when KC is
-        -- also blocked by Nature's Ally or on CD)
+        -- [src §ST #6 / Focus pooling] "Cobra Shot during BW if Barbed Shot <1.4
+        -- charges" - shipped profile uses the conservative Focus-pool proxy: skip
+        -- Cobra when Focus is low AND KC is castable. Avoids empty icons when KC
+        -- is also blocked (Nature's Ally / on CD).
+        -- NOTE: The underlying `resource` condition reads UnitPower("player", 2).
+        -- docs/API_CONSTRAINTS.md lists BM Focus as secret; docs/BM_ROTATION_REFERENCE.md
+        -- "Not Modeled" has a conflicting 2026-04-10 note that the call is readable.
+        -- This rule predates the Hunter-1.0 citation pass and is kept as-is pending
+        -- a live Focus probe run under `/ts probe`; treat the behaviour as heuristic.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 56641, -- Cobra Shot
@@ -169,6 +207,7 @@ local Profile = {
 function Profile:ResetState()
     self.state.blackArrowReady = true
     self.state.lastBlackArrowCast = 0
+    self.state.lastBWCast = 0
     self.state.witheringFireUntil = 0
     self.state.wailingArrowAvailable = false
     self.state.lastCastWasKC = false

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -1,5 +1,23 @@
--- TrueShot Profile: Beast Mastery / Pack Leader (Spec 253)
--- Simpler than Dark Ranger: BW management, Nature's Ally weaving
+-- TrueShot Profile: Beast Mastery / Pack Leader (specID 253)
+-- Hero path: Pack Leader (no markerSpell — BM fallback when Dark Ranger's Black Arrow marker is not known)
+--
+-- PRIMARY SOURCE
+--   Author:        Azortharion
+--   Guide:         Beast Mastery Hunter DPS Rotation, Cooldowns, and Abilities - Midnight Season 1
+--   URL:           https://www.icy-veins.com/wow/beast-mastery-hunter-pve-dps-rotation-cooldowns-abilities
+--   Guide updated: 2026-04-10
+--   Verified:      2026-04-18
+--   Patch:         12.0.4 (Midnight Season 1)
+--
+-- CROSS-CHECK SOURCES
+--   SimC midnight branch: ActionPriorityLists/default/hunter_beast_mastery.simc
+--   Wowhead:              https://www.wowhead.com/guide/classes/hunter/beast-mastery/rotation-cooldowns-pve-dps
+--                         (Tarlo, Patch 12.0.1, updated 2026-03-21)
+--
+-- DESIGN SCOPE
+--   Overlay profile on Blizzard Assisted Combat.
+--   Does NOT simulate hidden buff/resource state (see docs/API_CONSTRAINTS.md).
+--   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
 
 local Engine = TrueShot.Engine
 
@@ -16,12 +34,16 @@ local Profile = {
     specID = 253,
     -- No markerSpell: this profile serves as the BM fallback
     -- when Dark Ranger's Black Arrow marker does not match
-    version = 1,
+    version = 2,
 
     state = {
         lastBWCast = 0,
         lastCastWasKC = false,
         lastWildThrashCast = 0,
+        -- Stampede: armed by Bestial Wrath, consumed on the next Kill Command.
+        -- Source: Azortharion 2026-04-10 - "Activate Bestial Wrath. Once activated,
+        -- your next Kill Command will spawn a Stampede."
+        stampedeAvailable = false,
     },
 
     rotationalSpells = {
@@ -34,7 +56,7 @@ local Profile = {
         [53351]   = true, -- Kill Shot
     },
 
-    -- AoE hint: show Wild Thrash in secondary icon when 2+ hostile nameplates visible
+    -- [src §AoE #3] Wild Thrash on cooldown in multi-target.
     aoeHint = {
         spellID = 1264359, -- Wild Thrash
         condition = {
@@ -49,21 +71,37 @@ local Profile = {
     },
 
     rules = {
-        -- Filter utility spells
+        -- Filter utility spells (never part of the damage rotation).
         { type = "BLACKLIST", spellID = 883 },    -- Call Pet 1
         { type = "BLACKLIST", spellID = 982 },    -- Revive Pet
         { type = "BLACKLIST", spellID = 147362 }, -- Counter Shot (user preference)
 
-        -- Bestial Wrath: suppress only when on CD
-        -- Guide: dump BS charges before BW, hold a KC charge to enter with 2
+        -- [src §ST #2] "Activate Bestial Wrath" - leave BW available unless on CD.
+        -- The shipped profile does NOT gate BW on Barbed Shot charges: v0.9.0 removed
+        -- that gate after a prior WCL parse showed top players press BW immediately.
+        -- Azortharion text still recommends "dump charges first" - treat that as a
+        -- LIVE-verification follow-up rather than a static re-introduction.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 19574,
             condition = { type = "bw_on_cd" },
         },
 
-        -- Buffed Kill Command: absolute prio 1 when proc glow active
-        -- (Alpha Predator / Call of the Wild) - highest single-target damage
+        -- [src §ST #2b] Stampede: "your next Kill Command will spawn a Stampede"
+        -- after Bestial Wrath. Pin the first KC in the post-BW window to surface
+        -- the Stampede trigger even if AC has not prioritised KC yet.
+        -- Nature's Ally is satisfied because BW itself clears last_cast_was_kc.
+        {
+            type = "PIN",
+            spellID = 34026, -- Kill Command
+            reason = "Stampede",
+            condition = { type = "stampede_available" },
+        },
+
+        -- [src §ST #1] "Kill Command on cooldown with Nature's Ally up" - the KC
+        -- proc glow (Alpha Predator / Call of the Wild / Howl of the Pack Leader)
+        -- is a direct non-secret signal for a Nature's-Ally-buffed KC that AC does
+        -- not always prioritise on position 1.
         {
             type = "PIN",
             spellID = 34026, -- Kill Command
@@ -75,16 +113,24 @@ local Profile = {
             },
         },
 
-        -- Nature's Ally: never Kill Command twice in a row
+        -- [src §ST "Nature's Ally"] "Never cast Kill Command twice in a row."
+        -- Wild Thrash is NOT a valid Nature's Ally filler - the state machine
+        -- explicitly preserves last_cast_was_kc across WT casts.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 34026,
             condition = { type = "last_cast_was_kc" },
         },
 
-        -- Focus pooling: suppress Cobra Shot when Focus is too low for KC after,
-        -- but only when KC is actually castable (avoids blank icons when KC is
-        -- also blocked by Nature's Ally or on CD)
+        -- [src §ST #6 / Focus pooling] Suppress Cobra Shot when Focus is too low
+        -- to keep Kill Command castable afterwards. Gate also requires KC to be
+        -- castable, so a blocked KC (Nature's Ally, CD) does not leave the queue
+        -- empty.
+        -- NOTE: The underlying `resource` condition reads UnitPower("player", 2).
+        -- docs/API_CONSTRAINTS.md lists BM Focus as secret; docs/BM_ROTATION_REFERENCE.md
+        -- "Not Modeled" has a conflicting 2026-04-10 note that the call is readable.
+        -- This rule predates the Hunter-1.0 citation pass and is kept as-is pending
+        -- a live Focus probe run under `/ts probe`; treat the behaviour as heuristic.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 56641, -- Cobra Shot
@@ -103,8 +149,10 @@ local Profile = {
 ------------------------------------------------------------------------
 
 function Profile:ResetState()
+    self.state.lastBWCast = 0
     self.state.lastCastWasKC = false
     self.state.lastWildThrashCast = 0
+    self.state.stampedeAvailable = false
 end
 
 function Profile:OnSpellCast(spellID)
@@ -113,6 +161,7 @@ function Profile:OnSpellCast(spellID)
     if spellID == 19574 then -- Bestial Wrath
         s.lastBWCast = GetTime()
         s.lastCastWasKC = false
+        s.stampedeAvailable = true -- first KC after BW will trigger Stampede
 
     elseif spellID == 1264359 then -- Wild Thrash
         s.lastWildThrashCast = GetTime()
@@ -121,6 +170,7 @@ function Profile:OnSpellCast(spellID)
 
     elseif spellID == 34026 then -- Kill Command
         s.lastCastWasKC = true
+        s.stampedeAvailable = false -- consumed the Stampede proc window
 
     else
         s.lastCastWasKC = false
@@ -130,6 +180,7 @@ end
 function Profile:OnCombatEnd()
     self.state.lastCastWasKC = false
     self.state.lastWildThrashCast = 0
+    self.state.stampedeAvailable = false
 end
 
 ------------------------------------------------------------------------
@@ -150,6 +201,9 @@ function Profile:EvalCondition(cond)
         if s.lastWildThrashCast == 0 then return false end
         return (GetTime() - s.lastWildThrashCast) < WT_COOLDOWN
 
+    elseif cond.type == "stampede_available" then
+        return s.stampedeAvailable
+
     end
 
     return nil -- not handled by this profile
@@ -167,6 +221,7 @@ function Profile:GetDebugLines()
             and string.format("%.1fs elapsed (est ~%ds)", bwElapsed, BW_COOLDOWN)
             or "not cast yet"),
         "  Last cast was KC: " .. tostring(s.lastCastWasKC),
+        "  Stampede armed: " .. tostring(s.stampedeAvailable),
     }
 end
 
@@ -189,8 +244,9 @@ Engine:RegisterProfile(Profile)
 
 if TrueShot.CustomProfile then
     TrueShot.CustomProfile.RegisterConditionSchema("Hunter.BM.PackLeader", {
-        { id = "last_cast_was_kc", label = "Last Cast Was Kill Command", params = {} },
-        { id = "bw_on_cd",        label = "Bestial Wrath On Cooldown",  params = {} },
-        { id = "wt_on_cd",        label = "Wild Thrash On Cooldown",    params = {} },
+        { id = "last_cast_was_kc",   label = "Last Cast Was Kill Command", params = {} },
+        { id = "bw_on_cd",           label = "Bestial Wrath On Cooldown",  params = {} },
+        { id = "wt_on_cd",           label = "Wild Thrash On Cooldown",    params = {} },
+        { id = "stampede_available", label = "Stampede Armed (first KC after BW)", params = {} },
     })
 end

--- a/Profiles/MM_DarkRanger.lua
+++ b/Profiles/MM_DarkRanger.lua
@@ -1,6 +1,27 @@
--- TrueShot Profile: Marksmanship / Dark Ranger (Spec 254)
+-- TrueShot Profile: Marksmanship / Dark Ranger (specID 254)
+-- Hero path: Dark Ranger (marker: Black Arrow 466930 via IsPlayerSpell)
 -- Cast-event state machine for Black Arrow, Trueshot window, Wailing Arrow,
--- and Volley/Trueshot anti-overlap
+-- and Volley/Trueshot anti-overlap.
+--
+-- PRIMARY SOURCE
+--   Author:        Azortharion
+--   Guide:         Marksmanship Hunter DPS Rotation, Cooldowns, and Abilities - Midnight Season 1
+--   URL:           https://www.icy-veins.com/wow/marksmanship-hunter-pve-dps-rotation-cooldowns-abilities
+--   Guide updated: 2026-04-09
+--   Verified:      2026-04-18
+--   Patch:         12.0.4 (Midnight Season 1)
+--
+-- CROSS-CHECK SOURCES
+--   SimC midnight branch: ActionPriorityLists/default/hunter_marksmanship.simc
+--   Wowhead:              https://www.wowhead.com/guide/classes/hunter/marksmanship/rotation-cooldowns-pve-dps
+--                         (Patch 12.0.1, updated 2026/04/15)
+--
+-- DESIGN SCOPE
+--   Overlay profile on Blizzard Assisted Combat.
+--   Dark Ranger is the Black-Arrow-as-Kill-Shot lane; the rules below focus on
+--   the Trueshot -> BA -> WA -> BA opener, WF proc-window BA priority, and the
+--   Trueshot <-> Volley anti-overlap (Double Tap).
+--   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
 
 local Engine = TrueShot.Engine
 
@@ -58,25 +79,28 @@ local Profile = {
     },
 
     rules = {
-        -- Filter utility spells
+        -- Filter utility spells (never part of the damage rotation).
         { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
         { type = "BLACKLIST", spellID = SPELLS.RevivePet },
         { type = "BLACKLIST", spellID = SPELLS.CounterShot },
 
-        -- Anti-overlap: never Trueshot right after Volley (Double Tap waste)
+        -- [src §Sequencing "anti-overlap"] "Never cast Volley and Trueshot back-
+        -- to-back in any order, as this wastes Double Tap." Enforced in both
+        -- directions below.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = SPELLS.Trueshot,
             condition = { type = "volley_recent", seconds = 2 },
         },
-        -- Anti-overlap: never Volley right after Trueshot
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = SPELLS.Volley,
             condition = { type = "trueshot_just_cast", seconds = 2 },
         },
 
-        -- TS Opener: Black Arrow immediately after Trueshot (free proc)
+        -- [src §DR-Burst] "Trueshot -> Black Arrow -> Wailing Arrow -> Black
+        -- Arrow sequence maximizes proc utilization within cooldown windows."
+        -- Step 1: BA immediately after Trueshot (the free opener proc).
         {
             type = "PIN",
             spellID = SPELLS.BlackArrow,
@@ -88,7 +112,8 @@ local Profile = {
             },
         },
 
-        -- TS Opener: Wailing Arrow after spending the first BA proc
+        -- [src §DR-Burst step 3] Wailing Arrow after the first BA is spent
+        -- (procs the second free BA while still inside the Trueshot window).
         {
             type = "PIN",
             spellID = SPELLS.WailingArrow,
@@ -104,7 +129,9 @@ local Profile = {
             },
         },
 
-        -- General Withering Fire: Black Arrow is highest priority
+        -- [src §ST #1] "Black Arrow (cast on cooldown)" - Dark Ranger ranks BA as
+        -- the top-line spell. This PIN covers the extended BA-ready window the
+        -- profile models after Trueshot (see state.witheringFireUntil).
         {
             type = "PIN",
             spellID = SPELLS.BlackArrow,
@@ -116,7 +143,9 @@ local Profile = {
             },
         },
 
-        -- Trueshot: only after Rapid Fire and not after Volley
+        -- [src §Sequencing "Rapid Fire into Trueshot"] "Ideal setup follows
+        -- pattern: Rapid Fire -> Trueshot -> Aimed Shot." Pair the RF-recency
+        -- signal with the legal ac_suggested readiness gate for TS.
         {
             type = "PIN",
             spellID = SPELLS.Trueshot,
@@ -132,7 +161,9 @@ local Profile = {
             },
         },
 
-        -- Outside Withering Fire: prefer Black Arrow when ready
+        -- [src §ST #1 outside WF] BA outside the modelled WF proc window is a
+        -- soft hint, not an override: PREFER only. If AC already surfaces BA the
+        -- rule is a no-op; otherwise the queue bumps BA ahead of plain filler.
         {
             type = "PREFER",
             spellID = SPELLS.BlackArrow,

--- a/Profiles/MM_Sentinel.lua
+++ b/Profiles/MM_Sentinel.lua
@@ -1,6 +1,30 @@
--- TrueShot Profile: Marksmanship / Sentinel (Spec 254)
+-- TrueShot Profile: Marksmanship / Sentinel (specID 254)
+-- Hero path: Sentinel (no markerSpell - MM fallback when Dark Ranger's Black Arrow marker is not known)
 -- Cast-event state machine for Trueshot window, Volley anti-overlap,
--- and Moonlight Chakram filler timing
+-- and Moonlight Chakram filler timing.
+--
+-- PRIMARY SOURCE
+--   Author:        Azortharion
+--   Guide:         Marksmanship Hunter DPS Rotation, Cooldowns, and Abilities - Midnight Season 1
+--   URL:           https://www.icy-veins.com/wow/marksmanship-hunter-pve-dps-rotation-cooldowns-abilities
+--   Guide updated: 2026-04-09
+--   Verified:      2026-04-18
+--   Patch:         12.0.4 (Midnight Season 1)
+--
+-- CROSS-CHECK SOURCES
+--   SimC midnight branch: ActionPriorityLists/default/hunter_marksmanship.simc
+--   Wowhead MM Hero:      https://www.wowhead.com/guide/classes/hunter/marksmanship/hero-talents
+--                         "When you activate Trueshot, the Trueshot button itself will turn
+--                          into Moonlight Chakram, a filler ability that does heavy damage."
+--                         => Chakram is castable only inside the Trueshot window on Sentinel;
+--                            the BLACKLIST_CONDITIONAL below mirrors that spell-availability fact.
+--
+-- DESIGN SCOPE
+--   Overlay profile on Blizzard Assisted Combat.
+--   Sentinel lane is intentionally leaner than Dark Ranger: Trueshot/Volley anti-
+--   overlap, post-Rapid-Fire Trueshot timing, and Moonlight Chakram as a late
+--   Trueshot-window filler only.
+--   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
 
 local Engine = TrueShot.Engine
 
@@ -61,25 +85,27 @@ local Profile = {
     },
 
     rules = {
-        -- Filter utility spells
+        -- Filter utility spells (never part of the damage rotation).
         { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
         { type = "BLACKLIST", spellID = SPELLS.RevivePet },
         { type = "BLACKLIST", spellID = SPELLS.CounterShot },
 
-        -- Anti-overlap: never Trueshot right after Volley (Double Tap waste)
+        -- [src §Sequencing "anti-overlap"] "Never cast Volley and Trueshot back-
+        -- to-back in any order." Enforced in both directions.
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = SPELLS.Trueshot,
             condition = { type = "volley_recent", seconds = 2 },
         },
-        -- Anti-overlap: never Volley right after Trueshot
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = SPELLS.Volley,
             condition = { type = "trueshot_just_cast", seconds = 2 },
         },
 
-        -- Trueshot: only after Rapid Fire and not after Volley
+        -- [src §Sequencing "Rapid Fire into Trueshot"] "Ideal setup follows
+        -- pattern: Rapid Fire -> Trueshot -> Aimed Shot." Pair the RF-recency
+        -- signal with the legal ac_suggested readiness gate for TS.
         {
             type = "PIN",
             spellID = SPELLS.Trueshot,
@@ -95,14 +121,20 @@ local Profile = {
             },
         },
 
-        -- Block Moonlight Chakram outside Trueshot window (AC may still recommend it)
+        -- [src §Sentinel Hero, Wowhead] Moonlight Chakram replaces the Trueshot
+        -- button during the Trueshot buff, so it can only be cast inside the TS
+        -- window on Sentinel. Mirror that spell-availability fact by blacklisting
+        -- Chakram outside trueshot_active (guards against stray AC recommendations).
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = SPELLS.MoonlightChakram,
             condition = { type = "not", inner = { type = "trueshot_active" } },
         },
 
-        -- Moonlight Chakram: filler late in Trueshot when out of Aimed Shots
+        -- [src §ST #7] "Moonlight Chakram (filler when no Aimed Shots)" - elevate
+        -- Chakram only when AC already recommends it AND Aimed Shot has no
+        -- charges. PREFER (not PIN) so AC's own ordering wins when it already
+        -- leads with Chakram.
         {
             type = "PREFER",
             spellID = SPELLS.MoonlightChakram,

--- a/Profiles/SV_PackLeader.lua
+++ b/Profiles/SV_PackLeader.lua
@@ -1,6 +1,31 @@
--- TrueShot Profile: Survival / Pack Leader (Spec 255)
+-- TrueShot Profile: Survival / Pack Leader (specID 255)
+-- Hero path: Pack Leader (no markerSpell - SV fallback when Sentinel's Moonlight Chakram marker is not known)
 -- Cast-event state machine for Takedown window, Stampede sequencing,
--- WFB charge management, and Flamefang Pitch timing
+-- WFB charge management, and Flamefang Pitch timing.
+--
+-- PRIMARY SOURCE
+--   Author:        Azortharion
+--   Guide:         Survival Hunter DPS Rotation, Cooldowns, and Abilities - Midnight Season 1
+--   URL:           https://www.icy-veins.com/wow/survival-hunter-pve-dps-rotation-cooldowns-abilities
+--   Guide updated: 2026-03-27
+--   Verified:      2026-04-18
+--   Patch:         12.0.4 (Midnight Season 1)
+--
+-- CROSS-CHECK SOURCES
+--   SimC midnight branch: ActionPriorityLists/default/hunter_survival.simc
+--                         (plst / plcleave action lists)
+--   Wowhead:              https://www.wowhead.com/guide/classes/hunter/survival/rotation-cooldowns-pve-dps
+--                         (Patch 12.0.1, updated 2026-03-24)
+--
+-- DESIGN SCOPE
+--   Overlay profile on Blizzard Assisted Combat.
+--   Pack Leader's highest-value override is the Stampede/Howl-of-the-Pack-Leader
+--   trigger: "Takedown immediately procs Howl of the Pack Leader, causing your
+--   next Kill Command to summon a Beast. Your first Kill Command inside Takedown
+--   will also launch a Stampede." (Azortharion §PL Takedown Burst Window.)
+--   Tip-of-the-Spear stacks, Sentinel's Mark, and Fury-of-the-Wyvern are hidden
+--   buff state and are deliberately not modelled (see docs/API_CONSTRAINTS.md).
+--   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
 
 local Engine = TrueShot.Engine
 
@@ -51,12 +76,15 @@ local Profile = {
     },
 
     rules = {
-        -- Filter utility spells
+        -- Filter utility spells (never part of the damage rotation).
         { type = "BLACKLIST", spellID = SPELLS.Harpoon },
         { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
         { type = "BLACKLIST", spellID = SPELLS.RevivePet },
 
-        -- Stampede: first KC after Takedown triggers Stampede
+        -- [src §PL Takedown Burst] "Your first Kill Command inside Takedown will
+        -- also launch a Stampede." Pin KC for the first cast inside the 8s
+        -- Takedown buff window; once KC has fired inside that window the flag
+        -- flips and this rule no-ops until the next Takedown.
         {
             type = "PIN",
             spellID = SPELLS.KillCommand,
@@ -68,7 +96,10 @@ local Profile = {
             },
         },
 
-        -- Wildfire Bomb: spend at charge cap
+        -- [src §PL ST "Wildfire Bomb only to extend Fury of the Wyvern"] The
+        -- Wyvern-extension heuristic would need hidden buff state; ship the
+        -- conservative charge-cap proxy instead, which keeps the "never waste a
+        -- charge" intent under the Midnight API surface.
         {
             type = "PREFER",
             spellID = SPELLS.WildfireBomb,
@@ -76,7 +107,10 @@ local Profile = {
             condition = { type = "wfb_charges", op = "==", value = 2 },
         },
 
-        -- Boomstick: burst during Takedown window (suppress when on CD)
+        -- [src §PL ST #4 / AoE #5] "Boomstick" - generally high priority per
+        -- Azortharion. Shipped profile only PREFERs it inside Takedown (with a
+        -- local-timer CD gate) because outside the burst window AC already
+        -- surfaces it well; a wider PIN would fight AC more than it helps.
         {
             type = "PREFER",
             spellID = SPELLS.Boomstick,
@@ -88,7 +122,9 @@ local Profile = {
             },
         },
 
-        -- Flamefang Pitch: use when ready
+        -- [src §PL ST #3] "Flamefang Pitch on cooldown" - gate the PREFER on
+        -- ac_suggested so the override does not fire when AC already knows the
+        -- spell is not castable (keeps the rule legal under the CD-secret API).
         {
             type = "PREFER",
             spellID = SPELLS.FlamefangPitch,

--- a/Profiles/SV_Sentinel.lua
+++ b/Profiles/SV_Sentinel.lua
@@ -1,6 +1,29 @@
--- TrueShot Profile: Survival / Sentinel (Spec 255)
+-- TrueShot Profile: Survival / Sentinel (specID 255)
+-- Hero path: Sentinel (marker: Moonlight Chakram 1264902 via IsPlayerSpell)
 -- Cast-event state machine for Takedown burst window,
--- Wildfire Bomb charge management, and Moonlight Chakram timing
+-- Wildfire Bomb charge management, and Moonlight Chakram timing.
+--
+-- PRIMARY SOURCE
+--   Author:        Azortharion
+--   Guide:         Survival Hunter DPS Rotation, Cooldowns, and Abilities - Midnight Season 1
+--   URL:           https://www.icy-veins.com/wow/survival-hunter-pve-dps-rotation-cooldowns-abilities
+--   Guide updated: 2026-03-27
+--   Verified:      2026-04-18
+--   Patch:         12.0.4 (Midnight Season 1)
+--
+-- CROSS-CHECK SOURCES
+--   SimC midnight branch: ActionPriorityLists/default/hunter_survival.simc
+--                         (sentst / sentcleave action lists)
+--   Wowhead:              https://www.wowhead.com/guide/classes/hunter/survival/rotation-cooldowns-pve-dps
+--                         (Patch 12.0.1, updated 2026-03-24)
+--
+-- DESIGN SCOPE
+--   Overlay profile on Blizzard Assisted Combat.
+--   Sentinel's Mark proc state is hidden; the shipped profile uses the
+--   charge-count only path (`spell_charges >= 2`) for WFB and lets AC handle the
+--   Mark-driven timing. Boomstick is a PIN inside Takedown (with a local-timer
+--   CD gate), Moonlight Chakram is a PREFER early in the Takedown window.
+--   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
 
 local Engine = TrueShot.Engine
 
@@ -51,12 +74,16 @@ local Profile = {
     },
 
     rules = {
-        -- Filter utility spells
+        -- Filter utility spells (never part of the damage rotation).
         { type = "BLACKLIST", spellID = SPELLS.Harpoon },
         { type = "BLACKLIST", spellID = SPELLS.CallPet1 },
         { type = "BLACKLIST", spellID = SPELLS.RevivePet },
 
-        -- Prevent capping WFB charges while fishing Sentinel's Mark procs
+        -- [src §Sentinel ST #3] "Wildfire Bomb with Sentinel's Mark proc or <4
+        -- sec until 2 charges." Mark proc and precise recharge timing are hidden
+        -- state; ship the conservative "at 2 charges" charge-count path (validated
+        -- non-secret in docs/SIGNAL_VALIDATION.md) and let AC handle the
+        -- Mark-driven timing via its own internal state.
         {
             type = "PREFER",
             spellID = SPELLS.WildfireBomb,
@@ -64,7 +91,10 @@ local Profile = {
             condition = { type = "spell_charges", spellID = SPELLS.WildfireBomb, op = ">=", value = 2 },
         },
 
-        -- Boomstick pinned during Takedown burst (suppress when on CD)
+        -- [src §Sentinel ST #2] "Boomstick (high priority if Takedown unavailable,
+        -- no Sentinel's Mark proc)." Shipped PIN is narrower: only inside the
+        -- Takedown burst window and only when the local-timer CD gate permits,
+        -- since Boomstick readiness outside the burst depends on hidden state.
         {
             type = "PIN",
             spellID = SPELLS.Boomstick,
@@ -76,7 +106,10 @@ local Profile = {
             },
         },
 
-        -- Moonlight Chakram early in Takedown window (long damage)
+        -- [src §Sentinel ST #5] "Moonlight Chakram." Shipped profile scopes the
+        -- PREFER to the early Takedown window (takedown_just_cast < 5s) to avoid
+        -- fighting AC when Chakram would naturally surface later. Conservative
+        -- by design.
         {
             type = "PREFER",
             spellID = SPELLS.MoonlightChakram,
@@ -88,7 +121,8 @@ local Profile = {
             },
         },
 
-        -- Flamefang Pitch when ready
+        -- [src §Sentinel ST #6] "Flamefang Pitch on cooldown." Gate the PREFER
+        -- on ac_suggested so the override stays legal under the CD-secret API.
         {
             type = "PREFER",
             spellID = SPELLS.FlamefangPitch,

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Blizzard's built-in rotation helper gets you started, but it has gaps: wrong AoE
 
 TrueShot is built for Hunters first. Hunter is the class that should deliver clear practical value today, and all three specs are the standard the addon should be judged against.
 
+All six Hunter profiles are source-cited against Azortharion's current Midnight Season 1 rotation guides on Icy Veins (BM 2026-04-10, MM 2026-04-09, SV 2026-03-27), cross-checked against the SimC `midnight` branch default APL and the Wowhead Midnight rotation guides. Every rotational rule carries an `[src §<section> #N]` tag pointing at the priority step it implements; utility blacklists (pet / counter-shot / harpoon) are grouped without per-rule tags. The full source table per spec lives in [BM](docs/BM_ROTATION_REFERENCE.md) / [MM](docs/MM_ROTATION_REFERENCE.md) / [SV](docs/SV_ROTATION_REFERENCE.md) rotation references.
+
 The current release-readiness baseline for Hunter lives in [Hunter Validation Matrix](docs/HUNTER_VALIDATION_MATRIX.md). That document separates static confidence from the remaining live combat checks still needed for a clean `1.0` claim.
 
 | Spec | Hero Path | Key Overrides |
 |------|-----------|---------------|
 | **Beast Mastery** | Dark Ranger | Black Arrow during Withering Fire, Wailing Arrow sequencing, AoE hint for Wild Thrash |
-| **Beast Mastery** | Pack Leader | Nature's Ally KC weaving, Wild Thrash AoE hint, Bestial Wrath timing |
+| **Beast Mastery** | Pack Leader | Stampede pin (first KC after Bestial Wrath), Nature's Ally KC weaving, Wild Thrash AoE hint |
 | **Marksmanship** | Dark Ranger | Trueshot opener sequence, Volley/Trueshot anti-overlap, Withering Fire BA priority |
 | **Marksmanship** | Sentinel | Post-Rapid Fire Trueshot gating, Volley anti-overlap, Moonlight Chakram filler timing |
 | **Survival** | Pack Leader | Stampede KC sequencing, Boomstick CD tracking, Takedown burst window, Flamefang timing |

--- a/docs/BM_ROTATION_REFERENCE.md
+++ b/docs/BM_ROTATION_REFERENCE.md
@@ -1,8 +1,16 @@
 # BM Rotation Reference
 
-Source: Azortharion (Icy Veins BM Guide + Video Guide for Midnight Season 1)
-Video: https://youtu.be/GQiL-H8IZwA
-Supplementary: WCL analysis (40+ raid parses, 157 M+ parses)
+## Sources
+
+| Tier | Source | URL | Stamp |
+| --- | --- | --- | --- |
+| primary | Azortharion - Icy Veins BM Hunter Rotation | https://www.icy-veins.com/wow/beast-mastery-hunter-pve-dps-rotation-cooldowns-abilities | Guide 2026-04-10 / Patch 12.0.4 |
+| primary | Azortharion - BM Video Guide | https://youtu.be/GQiL-H8IZwA | Midnight Season 1 |
+| cross-check | SimC midnight branch | https://github.com/simulationcraft/simc/tree/midnight/ActionPriorityLists/default `hunter_beast_mastery.simc` | Midnight default APL |
+| cross-check | Wowhead - Tarlo | https://www.wowhead.com/guide/classes/hunter/beast-mastery/rotation-cooldowns-pve-dps | Patch 12.0.1, updated 2026-03-21 |
+| supplementary | WCL parse analysis (40+ raid, 157 M+) | private notes | aggregated prior to Midnight Season 1 |
+
+**Last reviewed: 2026-04-18** against the sources above.
 
 This document is the authoritative reference for rule ordering in `Profiles/BM_DarkRanger.lua` and `Profiles/BM_PackLeader.lua`. When profile rules are changed, verify them against this priority list.
 
@@ -71,8 +79,11 @@ Same as ST but add **Wild Thrash every 8 seconds on cooldown**. Wild Thrash:
 |------|------|-----------|-----------|
 | Call Pet / Revive Pet / Counter Shot | BLACKLIST | always | Utility, never rotation |
 | BW on CD | BLACKLIST_CONDITIONAL | bw_on_cd | Suppress when on CD |
+| **Stampede (first KC after BW)** | **PIN** | **stampede_available** | **[src Azortharion 2026-04-10] "Activate Bestial Wrath. Once activated, your next Kill Command will spawn a Stampede." Flag is armed on BW cast, cleared on the next KC cast.** |
+| KC proc glow | PIN | spell_glowing(KC) AND NOT last_cast_was_kc | Alpha Predator / Call of the Wild / Howl of the Pack Leader proc |
 | Wild Thrash AoE | AoE Hint | in_combat AND target_count >= 2 AND NOT wt_on_cd | On CD in multi-target |
 | KC anti-repeat | BLACKLIST_CONDITIONAL | last_cast_was_kc | Nature's Ally enforcement |
+| Cobra Shot Focus pool | BLACKLIST_CONDITIONAL | focus<65 AND KC usable | Avoid depleting Focus before KC |
 
 ---
 
@@ -168,7 +179,7 @@ Dump all BS charges before BW. Holding a KC charge to enter BW with 2 is worth i
 | Element | Reason |
 |---------|--------|
 | Beast Cleave uptime | Buff tracking is secret. Wild Thrash on CD provides 100% uptime. |
-| Focus management | UnitPower("player", 2) is readable (validated 2026-04-10). Resource condition type available in Engine for Focus pooling. |
+| Focus management | `UnitPower("player", 2)` is currently called via the `resource` condition type in Engine for a conservative Focus-pool heuristic. docs/API_CONSTRAINTS.md classifies Focus as secret/unsafe; a prior local note claimed the call was readable (2026-04-10) but this has not been re-probed under `/ts probe`. Treat the behaviour as heuristic until signal status is re-validated. |
 | Opener sequence | AC handles initial spells, profile rules take over after first cast events. |
 | Black Arrow availability (>80% HP / proc) | Proc state is secret. AC handles BA availability. |
 | Trinket usage | External to rotation logic. |

--- a/docs/HUNTER_VALIDATION_MATRIX.md
+++ b/docs/HUNTER_VALIDATION_MATRIX.md
@@ -8,12 +8,16 @@ Its purpose is simple:
 - separate static confidence from live combat proof
 - give each Hunter profile a repeatable checklist before `1.0`
 
+**Last source review: 2026-04-18** against the primary sources listed in each spec's rotation reference. Patch: 12.0.4 (Midnight Season 1). Primary author: Azortharion (Icy Veins).
+
 Use this together with:
 
 - [Project Goals](PROJECT_GOALS.md)
 - [API Constraints](API_CONSTRAINTS.md)
 - [Signal Validation](SIGNAL_VALIDATION.md)
 - [BM Rotation Reference](BM_ROTATION_REFERENCE.md)
+- [MM Rotation Reference](MM_ROTATION_REFERENCE.md)
+- [SV Rotation Reference](SV_ROTATION_REFERENCE.md)
 
 ## Readiness Model
 
@@ -97,6 +101,7 @@ These are the minimum live checks still needed before Hunter can honestly be cal
 
 - `Nature's Ally` / `Kill Command` weaving still behaves correctly in combat
 - `Bestial Wrath` timing and debug output align with the shipped profile behavior
+- **Stampede PIN**: first `Kill Command` after `Bestial Wrath` is surfaced as `reason = "Stampede"` in the queue; `stampedeAvailable` clears on that KC and re-arms on the next `Bestial Wrath` cast (shipped v0.24.0, sourced to Azortharion 2026-04-10).
 
 ### MM Dark Ranger
 
@@ -117,6 +122,18 @@ These are the minimum live checks still needed before Hunter can honestly be cal
 
 - `Wildfire Bomb` charge-cap spend behaves correctly in practice
 - `Moonlight Chakram` / `Flamefang` timing behaves correctly
+
+## Non-Hunter Isolation
+
+Non-Hunter profiles (Demon Hunter, Druid, Mage - foundation/alpha) ship in the same addon and register themselves alongside Hunter profiles, but they cannot affect Hunter loading or runtime. The isolation is mechanical, not advisory:
+
+1. `Engine:RegisterProfile(profile)` stores each profile under its own `specID` in `TrueShot.Profiles[specID]`.
+2. `Engine:ActivateProfile(specID)` only considers `TrueShot.Profiles[specID]` for the current spec.
+3. A Hunter on `253/254/255` therefore never sees Havoc (`577`), Feral (`103`), Fire (`63`), etc. as activation candidates.
+
+Profile files contain no top-level API calls beyond registration, so a non-Hunter profile failing cannot break the load chain for Hunter profiles. `luac -p` is run on every profile in `Profiles/` as a static syntax gate before release.
+
+If a non-Hunter profile ever needs to be shipped-but-disabled for a Hunter-only release, the surgical path is to remove its line from `TrueShot.toc` - not to edit the profile file.
 
 ## Release Rule
 

--- a/docs/MM_ROTATION_REFERENCE.md
+++ b/docs/MM_ROTATION_REFERENCE.md
@@ -1,5 +1,16 @@
 # MM Rotation Reference
 
+## Sources
+
+| Tier | Source | URL | Stamp |
+| --- | --- | --- | --- |
+| primary | Azortharion - Icy Veins MM Hunter Rotation | https://www.icy-veins.com/wow/marksmanship-hunter-pve-dps-rotation-cooldowns-abilities | Guide 2026-04-09 / Patch 12.0.4 |
+| cross-check | SimC midnight branch | https://github.com/simulationcraft/simc/tree/midnight/ActionPriorityLists/default `hunter_marksmanship.simc` | Midnight default APL |
+| cross-check | Wowhead MM Rotation | https://www.wowhead.com/guide/classes/hunter/marksmanship/rotation-cooldowns-pve-dps | Patch 12.0.1, updated 2026-04-15 |
+| spec fact | Wowhead Sentinel Hero | https://www.wowhead.com/guide/classes/hunter/marksmanship/hero-talents | Sentinel: Moonlight Chakram replaces the Trueshot button while Trueshot is active |
+
+**Last reviewed: 2026-04-18** against the sources above.
+
 This document is the authoritative shipped-rule reference for:
 
 - `Profiles/MM_DarkRanger.lua`

--- a/docs/SV_ROTATION_REFERENCE.md
+++ b/docs/SV_ROTATION_REFERENCE.md
@@ -1,5 +1,15 @@
 # SV Rotation Reference
 
+## Sources
+
+| Tier | Source | URL | Stamp |
+| --- | --- | --- | --- |
+| primary | Azortharion - Icy Veins SV Hunter Rotation | https://www.icy-veins.com/wow/survival-hunter-pve-dps-rotation-cooldowns-abilities | Guide 2026-03-27 / Patch 12.0.4 |
+| cross-check | SimC midnight branch | https://github.com/simulationcraft/simc/tree/midnight/ActionPriorityLists/default `hunter_survival.simc` | Midnight default APL (plst, plcleave, sentst, sentcleave) |
+| cross-check | Wowhead SV Rotation | https://www.wowhead.com/guide/classes/hunter/survival/rotation-cooldowns-pve-dps | Patch 12.0.1, updated 2026-03-24 |
+
+**Last reviewed: 2026-04-18** against the sources above.
+
 This document is the authoritative shipped-rule reference for:
 
 - `Profiles/SV_PackLeader.lua`

--- a/tests/test_hunter_profiles.lua
+++ b/tests/test_hunter_profiles.lua
@@ -1,0 +1,431 @@
+-- TrueShot Hunter profile logic tests
+-- Drives each of the 6 Hunter profiles through the scenarios its shipped rules
+-- claim to cover and checks the resulting state machine transitions.
+--
+-- Run from the addon root: lua tests/test_hunter_profiles.lua
+--
+-- Scope:
+--   - BM_DarkRanger:   Bestial Wrath, Black Arrow, Wailing Arrow, Kill Command state
+--   - BM_PackLeader:   Bestial Wrath, Stampede arming/consumption, Nature's Ally weave
+--   - MM_DarkRanger:   Trueshot, Black Arrow, Wailing Arrow, Rapid Fire, Volley state
+--   - MM_Sentinel:     Trueshot, Rapid Fire, Volley state
+--   - SV_PackLeader:   Takedown burst window, Stampede Kill Command flag, Boomstick CD
+--   - SV_Sentinel:     Takedown burst window, Boomstick CD
+--
+-- These are pure logic tests: no WoW client, no Engine wiring, no UI. They
+-- replace the Engine with a lightweight capturer that hands back the registered
+-- Profile table, then exercise it directly. GetTime() is a mutable stub so
+-- tests can move time forward deterministically.
+
+------------------------------------------------------------------------
+-- WoW client stubs
+------------------------------------------------------------------------
+
+local _time = 1000.0
+local function set_time(t) _time = t end
+local function advance_time(dt) _time = _time + dt end
+
+_G.GetTime = function() return _time end
+_G.UnitAffectingCombat = function(_) return true end
+_G.issecretvalue = function(_) return false end
+_G.pcall = pcall
+
+-- Minimal C_Spell stub: treat charges as a plain table keyed by spellID so tests
+-- can drive `spell_charges` conditions deterministically.
+local _charges = {}
+local function set_charges(spellID, current, max)
+    _charges[spellID] = { currentCharges = current, maxCharges = max or current }
+end
+_G.C_Spell = _G.C_Spell or {}
+_G.C_Spell.GetSpellCharges = function(spellID) return _charges[spellID] end
+
+-- MM Sentinel probes the player Trueshot aura as the primary signal, with a
+-- timer fallback only when the API is absent. Tests drive both paths by
+-- swapping the stub.
+_G.C_UnitAuras = _G.C_UnitAuras or {}
+local _auras_by_spell = {}
+local function set_player_aura(spellID, aura)
+    _auras_by_spell[spellID] = aura
+end
+_G.C_UnitAuras.GetPlayerAuraBySpellID = function(spellID)
+    return _auras_by_spell[spellID]
+end
+
+------------------------------------------------------------------------
+-- Minimal Engine + CustomProfile stubs that capture registered profiles
+------------------------------------------------------------------------
+
+TrueShot = {}
+local registered = {}
+
+TrueShot.Engine = {
+    RegisterProfile = function(_, profile)
+        registered[profile.id] = profile
+    end,
+}
+
+TrueShot.CustomProfile = {
+    RegisterConditionSchema = function(_, _) end,
+}
+
+------------------------------------------------------------------------
+-- Load all Hunter profiles into the capture table
+------------------------------------------------------------------------
+
+dofile("Profiles/BM_DarkRanger.lua")
+dofile("Profiles/BM_PackLeader.lua")
+dofile("Profiles/MM_DarkRanger.lua")
+dofile("Profiles/MM_Sentinel.lua")
+dofile("Profiles/SV_PackLeader.lua")
+dofile("Profiles/SV_Sentinel.lua")
+
+local function P(id)
+    local p = registered[id]
+    if not p then error("profile not registered: " .. id) end
+    return p
+end
+
+------------------------------------------------------------------------
+-- Test harness
+------------------------------------------------------------------------
+
+local passed, failed = 0, 0
+
+local function test(name, fn)
+    -- Reset each profile's state between tests so they do not leak.
+    for _, p in pairs(registered) do
+        if p.ResetState then p:ResetState() end
+    end
+    set_time(1000.0)
+    _charges = {}
+    _auras_by_spell = {}
+
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+    else
+        failed = failed + 1
+        print("FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_eq(a, b, msg)
+    if a ~= b then
+        error((msg or "") .. " expected " .. tostring(b) .. " got " .. tostring(a))
+    end
+end
+
+local function assert_true(v, msg)
+    if not v then error((msg or "expected true") .. " got " .. tostring(v)) end
+end
+
+local function assert_false(v, msg)
+    if v then error((msg or "expected false") .. " got " .. tostring(v)) end
+end
+
+------------------------------------------------------------------------
+-- BM Dark Ranger
+------------------------------------------------------------------------
+
+test("BM DR: Bestial Wrath opens Withering Fire and arms Wailing Arrow", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(19574) -- Bestial Wrath
+    assert_true(p:EvalCondition({ type = "in_withering_fire" }), "WF should be active immediately after BW")
+    assert_true(p:EvalCondition({ type = "wa_available" }), "Wailing Arrow should be available after BW")
+    assert_true(p:EvalCondition({ type = "ba_ready" }), "BW resets Black Arrow readiness")
+end)
+
+test("BM DR: Black Arrow cast clears ba_ready", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(19574) -- Bestial Wrath (arms BA)
+    assert_true(p:EvalCondition({ type = "ba_ready" }))
+    p:OnSpellCast(466930) -- Black Arrow
+    assert_false(p:EvalCondition({ type = "ba_ready" }), "BA should be on CD after cast")
+end)
+
+test("BM DR: Wailing Arrow cast re-arms Black Arrow and consumes WA", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(19574)  -- BW
+    p:OnSpellCast(466930) -- BA (spend first proc)
+    assert_false(p:EvalCondition({ type = "ba_ready" }))
+    p:OnSpellCast(392060) -- Wailing Arrow
+    assert_true(p:EvalCondition({ type = "ba_ready" }), "WA should re-arm BA")
+    assert_false(p:EvalCondition({ type = "wa_available" }), "WA should be consumed")
+end)
+
+test("BM DR: Withering Fire expires after 10s", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(19574)
+    advance_time(9)
+    assert_true(p:EvalCondition({ type = "in_withering_fire" }), "WF still active at 9s")
+    advance_time(2) -- total 11s after BW
+    assert_false(p:EvalCondition({ type = "in_withering_fire" }), "WF expired after 10s")
+end)
+
+test("BM DR: wf_ending fires only inside the final tail of WF", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(19574)
+    assert_false(p:EvalCondition({ type = "wf_ending", seconds = 2.5 }),
+        "wf_ending should be false at the start of WF")
+    advance_time(8) -- 2s remaining on WF
+    assert_true(p:EvalCondition({ type = "wf_ending", seconds = 2.5 }),
+        "wf_ending should fire in the last 2.5s of WF")
+end)
+
+test("BM DR: Kill Command sets Nature's Ally anti-repeat flag", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(34026) -- KC
+    assert_true(p:EvalCondition({ type = "last_cast_was_kc" }))
+    p:OnSpellCast(217200) -- Barbed Shot (valid NA filler)
+    assert_false(p:EvalCondition({ type = "last_cast_was_kc" }),
+        "Non-KC, non-WT cast should clear the NA flag")
+end)
+
+test("BM DR: Wild Thrash does NOT clear Nature's Ally flag (invalid weave)", function()
+    local p = P("Hunter.BM.DarkRanger")
+    p:OnSpellCast(34026)   -- KC
+    p:OnSpellCast(1264359) -- Wild Thrash
+    assert_true(p:EvalCondition({ type = "last_cast_was_kc" }),
+        "KC -> WT -> KC is an invalid weave; NA flag must remain true")
+end)
+
+------------------------------------------------------------------------
+-- BM Pack Leader (Stampede rule is the new v0.24.0 addition)
+------------------------------------------------------------------------
+
+test("BM PL: Bestial Wrath arms Stampede and clears NA flag", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(34026) -- KC first, to set NA flag
+    assert_true(p:EvalCondition({ type = "last_cast_was_kc" }))
+    p:OnSpellCast(19574) -- BW
+    assert_true(p:EvalCondition({ type = "stampede_available" }),
+        "BW must arm Stampede for the next KC")
+    assert_false(p:EvalCondition({ type = "last_cast_was_kc" }),
+        "BW clears the NA anti-repeat flag so the follow-up KC is legal")
+end)
+
+test("BM PL: first KC after BW consumes Stampede", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(19574) -- BW
+    assert_true(p:EvalCondition({ type = "stampede_available" }))
+    p:OnSpellCast(34026) -- KC
+    assert_false(p:EvalCondition({ type = "stampede_available" }),
+        "First KC after BW must consume the Stampede flag")
+end)
+
+test("BM PL: Stampede rearms on next Bestial Wrath", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(19574) -- BW
+    p:OnSpellCast(34026) -- KC (consumes)
+    assert_false(p:EvalCondition({ type = "stampede_available" }))
+    p:OnSpellCast(19574) -- next BW
+    assert_true(p:EvalCondition({ type = "stampede_available" }),
+        "Next BW must re-arm Stampede")
+end)
+
+test("BM PL: Combat end clears Stampede flag", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(19574)
+    assert_true(p:EvalCondition({ type = "stampede_available" }))
+    p:OnCombatEnd()
+    assert_false(p:EvalCondition({ type = "stampede_available" }),
+        "OnCombatEnd must clear Stampede to avoid stale arming between fights")
+end)
+
+test("BM PL: Stampede PIN is ordered before the KC Proc PIN (first-match-wins)", function()
+    local p = P("Hunter.BM.PackLeader")
+    local stampedeIdx, kcProcIdx = nil, nil
+    for i, rule in ipairs(p.rules) do
+        if rule.type == "PIN" and rule.spellID == 34026 then
+            if rule.reason == "Stampede" then stampedeIdx = i
+            elseif rule.reason == "KC Proc" then kcProcIdx = i end
+        end
+    end
+    assert_true(stampedeIdx, "Stampede PIN rule must exist")
+    assert_true(kcProcIdx, "KC Proc PIN rule must exist")
+    assert_true(stampedeIdx < kcProcIdx,
+        "Engine ComputeQueue iterates rules in order and takes the first PIN whose " ..
+        "condition is true (Engine.lua:337). To make the post-BW queue surface " ..
+        "reason='Stampede', the Stampede rule must be declared before the KC Proc rule.")
+end)
+
+test("BM PL: bw_on_cd blocks re-cast inside the 30s window", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(19574)
+    advance_time(10)
+    assert_true(p:EvalCondition({ type = "bw_on_cd" }), "BW should be on CD at +10s")
+    advance_time(25) -- total 35s, past the 30s CD
+    assert_false(p:EvalCondition({ type = "bw_on_cd" }), "BW should be off CD at +35s")
+end)
+
+test("BM PL: Wild Thrash does NOT clear Nature's Ally flag", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(34026)
+    p:OnSpellCast(1264359) -- WT
+    assert_true(p:EvalCondition({ type = "last_cast_was_kc" }),
+        "WT must not be treated as a Nature's Ally filler")
+end)
+
+------------------------------------------------------------------------
+-- MM Dark Ranger
+------------------------------------------------------------------------
+
+test("MM DR: Trueshot arms BA readiness, WF timer, and Wailing Arrow", function()
+    local p = P("Hunter.MM.DarkRanger")
+    p:OnSpellCast(288613) -- Trueshot
+    assert_true(p:EvalCondition({ type = "ba_ready" }))
+    assert_true(p:EvalCondition({ type = "in_withering_fire" }))
+    assert_true(p:EvalCondition({ type = "wa_available" }))
+    assert_true(p:EvalCondition({ type = "trueshot_active" }))
+    assert_true(p:EvalCondition({ type = "trueshot_just_cast", seconds = 2 }))
+end)
+
+test("MM DR: trueshot_just_cast decays after its window", function()
+    local p = P("Hunter.MM.DarkRanger")
+    p:OnSpellCast(288613)
+    advance_time(3)
+    assert_false(p:EvalCondition({ type = "trueshot_just_cast", seconds = 2 }),
+        "trueshot_just_cast window should have elapsed")
+    assert_true(p:EvalCondition({ type = "trueshot_active" }),
+        "Trueshot buff should still be active well before the 15s duration ends")
+end)
+
+test("MM DR: Rapid Fire recency is bounded by the seconds arg", function()
+    local p = P("Hunter.MM.DarkRanger")
+    p:OnSpellCast(257044) -- Rapid Fire
+    assert_true(p:EvalCondition({ type = "rapid_fire_recent", seconds = 3 }))
+    advance_time(4)
+    assert_false(p:EvalCondition({ type = "rapid_fire_recent", seconds = 3 }))
+end)
+
+test("MM DR: Volley anti-overlap signal decays after seconds", function()
+    local p = P("Hunter.MM.DarkRanger")
+    p:OnSpellCast(260243) -- Volley
+    assert_true(p:EvalCondition({ type = "volley_recent", seconds = 2 }))
+    advance_time(3)
+    assert_false(p:EvalCondition({ type = "volley_recent", seconds = 2 }))
+end)
+
+------------------------------------------------------------------------
+-- MM Sentinel
+------------------------------------------------------------------------
+
+test("MM Sentinel: trueshot_active reads live aura when present", function()
+    local p = P("Hunter.MM.Sentinel")
+    p:OnSpellCast(288613)
+    set_player_aura(288613, { spellId = 288613 }) -- Trueshot aura live
+    assert_true(p:EvalCondition({ type = "trueshot_active" }),
+        "With a live aura the primary signal should resolve true")
+end)
+
+test("MM Sentinel: trueshot_active is false when the aura is gone", function()
+    local p = P("Hunter.MM.Sentinel")
+    p:OnSpellCast(288613)
+    -- No aura set => API returns nil => primary signal says inactive.
+    assert_false(p:EvalCondition({ type = "trueshot_active" }),
+        "Primary aura signal takes precedence over the timer fallback")
+end)
+
+test("MM Sentinel: timer fallback engages when C_UnitAuras API is absent", function()
+    local p = P("Hunter.MM.Sentinel")
+    local saved = _G.C_UnitAuras.GetPlayerAuraBySpellID
+    _G.C_UnitAuras.GetPlayerAuraBySpellID = nil
+    p:OnSpellCast(288613)
+    assert_true(p:EvalCondition({ type = "trueshot_active" }),
+        "With the aura API missing, the 19s timer must cover the Trueshot window")
+    advance_time(20)
+    assert_false(p:EvalCondition({ type = "trueshot_active" }),
+        "Timer fallback should expire after the 19s Sentinel Trueshot window")
+    _G.C_UnitAuras.GetPlayerAuraBySpellID = saved
+end)
+
+test("MM Sentinel: aimed_shot_ready reads non-secret charges", function()
+    local p = P("Hunter.MM.Sentinel")
+    set_charges(19434, 2, 2)
+    assert_true(p:EvalCondition({ type = "aimed_shot_ready" }))
+    set_charges(19434, 0, 2)
+    assert_false(p:EvalCondition({ type = "aimed_shot_ready" }))
+end)
+
+------------------------------------------------------------------------
+-- SV Pack Leader
+------------------------------------------------------------------------
+
+test("SV PL: Takedown opens 8s burst window", function()
+    local p = P("Hunter.SV.PackLeader")
+    p:OnSpellCast(1250646) -- Takedown
+    assert_true(p:EvalCondition({ type = "takedown_active" }))
+    assert_false(p:EvalCondition({ type = "kc_cast_in_takedown" }))
+    advance_time(9)
+    assert_false(p:EvalCondition({ type = "takedown_active" }),
+        "Takedown burst window is 8s; should be closed at +9s")
+end)
+
+test("SV PL: first KC inside Takedown sets kc_cast_in_takedown", function()
+    local p = P("Hunter.SV.PackLeader")
+    p:OnSpellCast(1250646) -- Takedown
+    p:OnSpellCast(259489)  -- SV Kill Command (259489, distinct from BM 34026)
+    assert_true(p:EvalCondition({ type = "kc_cast_in_takedown" }),
+        "KC cast inside Takedown window must set the Stampede-consumed flag")
+end)
+
+test("SV PL: KC outside Takedown does NOT set kc_cast_in_takedown", function()
+    local p = P("Hunter.SV.PackLeader")
+    p:OnSpellCast(1250646)
+    advance_time(9) -- Takedown window closed
+    p:OnSpellCast(259489)
+    assert_false(p:EvalCondition({ type = "kc_cast_in_takedown" }),
+        "Late KC should not retroactively flag a consumed Stampede")
+end)
+
+test("SV PL: Boomstick tracks its own 30s CD signal", function()
+    local p = P("Hunter.SV.PackLeader")
+    p:OnSpellCast(1261193) -- Boomstick
+    assert_true(p:EvalCondition({ type = "boomstick_on_cd" }))
+    advance_time(31)
+    assert_false(p:EvalCondition({ type = "boomstick_on_cd" }))
+end)
+
+test("SV PL: WFB charges condition respects operators", function()
+    local p = P("Hunter.SV.PackLeader")
+    set_charges(259495, 2, 2)
+    assert_true(p:EvalCondition({ type = "wfb_charges", op = "==", value = 2 }))
+    set_charges(259495, 1, 2)
+    assert_false(p:EvalCondition({ type = "wfb_charges", op = "==", value = 2 }))
+    assert_true(p:EvalCondition({ type = "wfb_charges", op = ">=", value = 1 }))
+end)
+
+------------------------------------------------------------------------
+-- SV Sentinel
+------------------------------------------------------------------------
+
+test("SV Sentinel: Takedown opens its 8s burst window", function()
+    local p = P("Hunter.SV.Sentinel")
+    p:OnSpellCast(1250646)
+    assert_true(p:EvalCondition({ type = "takedown_active" }))
+    assert_true(p:EvalCondition({ type = "takedown_just_cast", seconds = 5 }))
+    advance_time(6)
+    assert_false(p:EvalCondition({ type = "takedown_just_cast", seconds = 5 }))
+    assert_true(p:EvalCondition({ type = "takedown_active" }),
+        "takedown_active spans the full 8s even after takedown_just_cast's 5s hint expires")
+end)
+
+test("SV Sentinel: Boomstick cooldown gate tracks cast recency", function()
+    local p = P("Hunter.SV.Sentinel")
+    p:OnSpellCast(1261193)
+    assert_true(p:EvalCondition({ type = "boomstick_on_cd" }))
+    advance_time(31)
+    assert_false(p:EvalCondition({ type = "boomstick_on_cd" }))
+end)
+
+test("SV Sentinel: OnCombatEnd clears Takedown window", function()
+    local p = P("Hunter.SV.Sentinel")
+    p:OnSpellCast(1250646)
+    p:OnCombatEnd()
+    assert_false(p:EvalCondition({ type = "takedown_active" }),
+        "Combat-end must not leave stale Takedown burst state")
+end)
+
+------------------------------------------------------------------------
+print(string.format("\n%d passed, %d failed", passed, failed))
+if failed > 0 then os.exit(1) end


### PR DESCRIPTION
## Summary

- **New rule**: BM Pack Leader Stampede PIN. First Kill Command after Bestial Wrath is now pinned as `reason = "Stampede"`. Sourced to Azortharion's Icy Veins BM Hunter Rotation (guide updated 2026-04-10, Midnight Season 1 / Patch 12.0.4): *"Activate Bestial Wrath. Once activated, your next Kill Command will spawn a Stampede."*
- **Source citations**: Every Hunter profile file carries a structured PRIMARY SOURCE / CROSS-CHECK / DESIGN SCOPE header block with URL, guide-update date, verified-on date, patch, and hero path. Rotational rules carry inline `[src §<section> #N]` tags pointing at the guide priority step they implement; utility blacklists (pet / counter-shot / harpoon) are grouped without per-rule tags.
- **Docs**: BM / MM / SV Rotation Reference each got a Sources table with tier, URL, and stamp. `HUNTER_VALIDATION_MATRIX.md` got a Non-Hunter Isolation section documenting the mechanical `specID`-routing guarantee, and the BM Pack Leader live-check list now includes the Stampede PIN surfacing.
- **ResetState hardening**: Both BM profiles now clear `lastBWCast` in `ResetState`, preventing stale Bestial Wrath timestamps from carrying across profile switches.
- **Focus-pool commentary softened**: the `resource`-condition Focus read is labelled heuristic pending a live `/ts probe` run, consistent with `docs/API_CONSTRAINTS.md`.
- **Tests**: new `tests/test_hunter_profiles.lua` with 30 scenario tests for all six Hunter profiles: state machines, `EvalCondition` transitions, Nature's Ally anti-repeat (including the `KC -> WT -> KC` invalid-weave guard), Stampede arming/consumption, MM Sentinel aura-vs-timer fallback, and a structural-ordering guard that the Stampede PIN precedes the KC Proc PIN in the rules array.

## Test plan

- [x] `luac -p` on all 20 profile files
- [x] `lua tests/test_hunter_profiles.lua` — 30 passed, 0 failed
- [x] `lua tests/test_condition_registry.lua` — 12 passed, 0 failed
- [x] `lua tests/test_base64_decode.lua` — 8 passed, 0 failed
- [ ] Live in-game verification per spec / hero path (closes the `LIVE` pending rows in `docs/HUNTER_VALIDATION_MATRIX.md`)

## Release target

- Version: v0.24.0
- Interface: 120000 (loads on live 12.0.4 and expected 12.0.5 without bump)
- Scope: Hunter (primary), non-Hunter profiles remain foundation/alpha and are isolated via `specID` routing in `Engine:ActivateProfile`.