### PR TITLE
v0.25.0: State/CDLedger + BM Pack Leader pilot migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.25.0 - 2026-04-18
+
+### Added
+- **`State/CDLedger.lua`**: central, data-driven cooldown tracker for Hunter rotational spells. Listens to `UNIT_SPELLCAST_SUCCEEDED`, resolves base cooldown through `GetSpellBaseCooldown` (with hardcoded `spec.base_ms` fallback), applies haste scaling through `UnitSpellHaste("player")` for spells flagged `haste_scaled`. Every live API read is guarded with `pcall` + `issecretvalue` and degrades cleanly to the spec fallback when the client returns secret values. Closes [#84](https://github.com/itsDNNS/TrueShot/issues/84).
+- **Engine conditions `cd_ready(spellID)` and `cd_remaining(spellID, op, value)`**: new first-class condition types available to every profile and to the Visual Rule Builder. Registered in `CustomProfile` so they show up in the picker alongside `spell_charges`, `spell_glowing`, etc.
+- **`State/` framework layer**: documented in `docs/FRAMEWORK.md`. Owns shared, class-agnostic state that multiple profiles query through engine conditions.
+- **`/ts probe cd`**: new probe command that reports `GetSpellBaseCooldown`, `UnitSpellHaste("player")`, and `C_Spell.GetSpellCooldown` values (plus secrecy) for every spell the ledger tracks. Feeds into `docs/SIGNAL_VALIDATION.md` classifications.
+- **`tests/test_cd_ledger.lua`**: 19 scenario tests covering spec coverage, base-CD resolution (spec fallback, live override, secret-guard), haste scaling (flag on/off, API present/absent), reset and reduction hooks, lifecycle (OnCombatEnd does not reset, Reset clears all), and secret-spellID protection.
+
+### Changed
+- **`Profiles/BM_PackLeader.lua` pilot migration**: drops `BW_COOLDOWN`, `WT_COOLDOWN`, `lastBWCast`, and `lastWildThrashCast` in favour of ledger-owned timing. Rules now use `cd_ready` / `cd_remaining` directly. Phase detection ("Burst" window) reads `CDLedger:SecondsSinceCast(Bestial Wrath)` instead of a profile-local timestamp. Legacy `bw_on_cd` / `wt_on_cd` conditions remain as thin backward-compat shims that delegate to the ledger, and their schema entries are kept (marked legacy) so Visual Rule Builder nodes authored before v0.25.0 still round-trip through the picker. User-forked custom profiles in SavedVariables keep evaluating correctly.
+- **Intentional semantic shift**: the ledger preserves cooldown state across `PLAYER_REGEN_ENABLED` (real in-game cooldowns persist across combat end). The pre-v0.25.0 `BM_PackLeader` cleared `lastWildThrashCast` on combat end; the new ledger-owned timer stays through. The `OnCombatEnd` no-op is covered by a test.
+- **`docs/SIGNAL_VALIDATION.md`** adds three new signal entries (Base Cooldown Lookup, Spell Haste, Cooldown Read Per-Spell) and lists `/ts probe cd` under the probe commands.
+- **`docs/PROFILE_CONTRACT.md`** enumerates the engine-level state conditions and documents `cd_ready` / `cd_remaining` as the preferred path for new rules.
+- **`docs/API_CONSTRAINTS.md`** adds the CDLedger pattern to the approved-heuristic list.
+
 ## v0.24.0 - 2026-04-18
 
 ### Added

--- a/Core.lua
+++ b/Core.lua
@@ -165,6 +165,12 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
     elseif event == "UNIT_SPELLCAST_SUCCEEDED" then
         local unit, _, spellID = ...
         if unit == "player" and spellID then
+            -- CDLedger runs alongside the profile dispatch so timer state is
+            -- updated before any condition (including the one that just fired
+            -- this cast through MarkDirty) re-evaluates.
+            if TrueShot.CDLedger and TrueShot.CDLedger.OnSpellCastSucceeded then
+                TrueShot.CDLedger:OnSpellCastSucceeded(spellID)
+            end
             Engine:OnSpellCast(spellID)
             if Display then
                 if Display.OnSpellCastSucceeded then

--- a/CustomProfile.lua
+++ b/CustomProfile.lua
@@ -100,6 +100,14 @@ CustomProfile.RegisterConditionSchema("_engine", {
           { field = "op",        fieldType = "operator", choices = {">=", ">", "==", "<", "<="}, default = ">=" },
           { field = "value",     fieldType = "number", default = 50, label = "Amount" },
       }},
+    { id = "cd_ready",        label = "Cooldown Ready",
+      params = { { field = "spellID", fieldType = "spell", label = "Spell" } } },
+    { id = "cd_remaining",    label = "Cooldown Remaining",
+      params = {
+          { field = "spellID", fieldType = "spell", label = "Spell" },
+          { field = "op",      fieldType = "operator", choices = {">=", ">", "==", "<", "<="}, default = ">" },
+          { field = "value",   fieldType = "number", default = 0, label = "Seconds" },
+      }},
 })
 
 ------------------------------------------------------------------------

--- a/Engine.lua
+++ b/Engine.lua
@@ -225,6 +225,22 @@ function Engine:EvalCondition(cond)
         end
         return false
 
+    elseif cond.type == "cd_ready" then
+        if TrueShot.CDLedger then
+            return TrueShot.CDLedger:IsOnCooldown(cond.spellID) == false
+        end
+        return false
+
+    elseif cond.type == "cd_remaining" then
+        if not TrueShot.CDLedger then return false end
+        local remaining = TrueShot.CDLedger:SecondsUntilReady(cond.spellID)
+        if cond.op == ">=" then return remaining >= cond.value end
+        if cond.op == ">"  then return remaining >  cond.value end
+        if cond.op == "==" then return remaining == cond.value end
+        if cond.op == "<"  then return remaining <  cond.value end
+        if cond.op == "<=" then return remaining <= cond.value end
+        return false
+
     elseif cond.type == "burst_mode" then
         return self.burstModeActive
 

--- a/Profiles/BM_PackLeader.lua
+++ b/Profiles/BM_PackLeader.lua
@@ -18,11 +18,15 @@
 --   Overlay profile on Blizzard Assisted Combat.
 --   Does NOT simulate hidden buff/resource state (see docs/API_CONSTRAINTS.md).
 --   Inline tags "[src §<section> #N]" reference the priority number in the primary source.
+--
+-- PILOT MIGRATION (v0.25.0, issue #84)
+--   This profile is the first consumer of State/CDLedger. Cooldown tracking for
+--   Bestial Wrath and Wild Thrash no longer lives on profile-local timestamps;
+--   the ledger owns `cd_remaining(spellID, op, value)`. The legacy
+--   `bw_on_cd` / `wt_on_cd` conditions remain as thin EvalCondition shims so
+--   user-forked custom profiles in SavedVariables keep working.
 
 local Engine = TrueShot.Engine
-
-local BW_COOLDOWN = 30
-local WT_COOLDOWN = 8
 
 ------------------------------------------------------------------------
 -- Profile definition
@@ -34,12 +38,10 @@ local Profile = {
     specID = 253,
     -- No markerSpell: this profile serves as the BM fallback
     -- when Dark Ranger's Black Arrow marker does not match
-    version = 2,
+    version = 3,
 
     state = {
-        lastBWCast = 0,
         lastCastWasKC = false,
-        lastWildThrashCast = 0,
         -- Stampede: armed by Bestial Wrath, consumed on the next Kill Command.
         -- Source: Azortharion 2026-04-10 - "Activate Bestial Wrath. Once activated,
         -- your next Kill Command will spawn a Stampede."
@@ -65,7 +67,7 @@ local Profile = {
             right = {
                 type = "and",
                 left  = { type = "target_count", op = ">=", value = 2 },
-                right = { type = "not", inner = { type = "wt_on_cd" } },
+                right = { type = "cd_ready", spellID = 1264359 },
             },
         },
     },
@@ -84,7 +86,7 @@ local Profile = {
         {
             type = "BLACKLIST_CONDITIONAL",
             spellID = 19574,
-            condition = { type = "bw_on_cd" },
+            condition = { type = "cd_remaining", spellID = 19574, op = ">", value = 0 },
         },
 
         -- [src §ST #2b] Stampede: "your next Kill Command will spawn a Stampede"
@@ -149,9 +151,7 @@ local Profile = {
 ------------------------------------------------------------------------
 
 function Profile:ResetState()
-    self.state.lastBWCast = 0
     self.state.lastCastWasKC = false
-    self.state.lastWildThrashCast = 0
     self.state.stampedeAvailable = false
 end
 
@@ -159,12 +159,10 @@ function Profile:OnSpellCast(spellID)
     local s = self.state
 
     if spellID == 19574 then -- Bestial Wrath
-        s.lastBWCast = GetTime()
         s.lastCastWasKC = false
         s.stampedeAvailable = true -- first KC after BW will trigger Stampede
 
     elseif spellID == 1264359 then -- Wild Thrash
-        s.lastWildThrashCast = GetTime()
         -- NOTE: Wild Thrash does NOT grant Nature's Ally.
         -- Do NOT clear lastCastWasKC here. KC -> WT -> KC is invalid.
 
@@ -179,12 +177,15 @@ end
 
 function Profile:OnCombatEnd()
     self.state.lastCastWasKC = false
-    self.state.lastWildThrashCast = 0
     self.state.stampedeAvailable = false
 end
 
 ------------------------------------------------------------------------
 -- Profile-specific condition evaluation
+--
+-- `bw_on_cd` / `wt_on_cd` are kept as backward-compat shims that delegate to
+-- the CDLedger. User-forked custom profiles stored in SavedVariables may still
+-- reference these IDs; new rules should use `cd_remaining(spellID, op, value)`.
 ------------------------------------------------------------------------
 
 function Profile:EvalCondition(cond)
@@ -193,16 +194,22 @@ function Profile:EvalCondition(cond)
     if cond.type == "last_cast_was_kc" then
         return s.lastCastWasKC
 
-    elseif cond.type == "bw_on_cd" then
-        if s.lastBWCast == 0 then return false end
-        return (GetTime() - s.lastBWCast) < BW_COOLDOWN
-
-    elseif cond.type == "wt_on_cd" then
-        if s.lastWildThrashCast == 0 then return false end
-        return (GetTime() - s.lastWildThrashCast) < WT_COOLDOWN
-
     elseif cond.type == "stampede_available" then
         return s.stampedeAvailable
+
+    elseif cond.type == "bw_on_cd" then
+        -- Legacy shim: Bestial Wrath on cooldown.
+        if TrueShot.CDLedger then
+            return TrueShot.CDLedger:IsOnCooldown(19574)
+        end
+        return false
+
+    elseif cond.type == "wt_on_cd" then
+        -- Legacy shim: Wild Thrash on cooldown.
+        if TrueShot.CDLedger then
+            return TrueShot.CDLedger:IsOnCooldown(1264359)
+        end
+        return false
 
     end
 
@@ -215,11 +222,11 @@ end
 
 function Profile:GetDebugLines()
     local s = self.state
-    local bwElapsed = s.lastBWCast > 0 and (GetTime() - s.lastBWCast) or 0
+    local bwRemaining = TrueShot.CDLedger and TrueShot.CDLedger:SecondsUntilReady(19574) or 0
     return {
-        "  BW CD: " .. (s.lastBWCast > 0
-            and string.format("%.1fs elapsed (est ~%ds)", bwElapsed, BW_COOLDOWN)
-            or "not cast yet"),
+        "  BW CD: " .. (bwRemaining > 0
+            and string.format("%.1fs remaining", bwRemaining)
+            or "ready"),
         "  Last cast was KC: " .. tostring(s.lastCastWasKC),
         "  Stampede armed: " .. tostring(s.stampedeAvailable),
     }
@@ -227,12 +234,17 @@ end
 
 ------------------------------------------------------------------------
 -- Phase detection (for overlay display)
+--
+-- "Burst" while the Bestial Wrath buff window is assumed active (~15s after
+-- the cast). Uses CDLedger's cast-timestamp rather than a duplicated profile
+-- timer.
 ------------------------------------------------------------------------
 
 function Profile:GetPhase()
     if not UnitAffectingCombat("player") then return nil end
-    local s = self.state
-    if s.lastBWCast > 0 and (GetTime() - s.lastBWCast) < 15 then return "Burst" end
+    if not TrueShot.CDLedger then return nil end
+    local sinceCast = TrueShot.CDLedger:SecondsSinceCast(19574)
+    if sinceCast and sinceCast < 15 then return "Burst" end
     return nil
 end
 
@@ -243,10 +255,15 @@ end
 Engine:RegisterProfile(Profile)
 
 if TrueShot.CustomProfile then
+    -- Schema includes deprecated `bw_on_cd` / `wt_on_cd` so Visual Rule Builder
+    -- nodes authored before v0.25.0 still round-trip through the picker. New
+    -- rules should prefer the engine-level `cd_ready` / `cd_remaining` entries
+    -- (registered in CustomProfile). The shim EvalCondition cases above
+    -- delegate both legacy IDs to the CDLedger.
     TrueShot.CustomProfile.RegisterConditionSchema("Hunter.BM.PackLeader", {
-        { id = "last_cast_was_kc",   label = "Last Cast Was Kill Command", params = {} },
-        { id = "bw_on_cd",           label = "Bestial Wrath On Cooldown",  params = {} },
-        { id = "wt_on_cd",           label = "Wild Thrash On Cooldown",    params = {} },
+        { id = "last_cast_was_kc",   label = "Last Cast Was Kill Command",         params = {} },
         { id = "stampede_available", label = "Stampede Armed (first KC after BW)", params = {} },
+        { id = "bw_on_cd",           label = "Bestial Wrath On Cooldown (legacy, use cd_remaining)", params = {} },
+        { id = "wt_on_cd",           label = "Wild Thrash On Cooldown (legacy, use cd_remaining)",   params = {} },
     })
 end

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The addon is:
 - **Transparent**: shows why it overrode AC (reason labels, phase indicators)
 - **Fail-safe**: degrades gracefully to pure AC passthrough if signals are unavailable
 
+## State Layer
+
+Starting in v0.25.0, TrueShot has a `State/` layer that owns class-agnostic shared state multiple profiles can query through engine conditions. The first module is `State/CDLedger.lua`, a central cooldown tracker fed by `UNIT_SPELLCAST_SUCCEEDED` with `GetSpellBaseCooldown` as the base-CD source and haste-aware scaling for spells flagged `haste_scaled`. Profiles use the engine conditions `cd_ready(spellID)` and `cd_remaining(spellID, op, value)` instead of duplicated local timers. `Hunter.BM.PackLeader` is the first migrated profile; the remaining Hunter profiles migrate incrementally.
+
 ## Framework Docs
 
 - [Project Goals](docs/PROJECT_GOALS.md)

--- a/SignalProbe.lua
+++ b/SignalProbe.lua
@@ -499,6 +499,74 @@ function Probe:SpellOverlay()
 end
 
 ------------------------------------------------------------------------
+-- Probe: CDLedger dependencies
+--
+-- Reports the secrecy and value of GetSpellBaseCooldown, UnitSpellHaste, and
+-- C_Spell.GetSpellCooldown for every spell currently in State/CDLedger.spec.
+-- Results feed into docs/SIGNAL_VALIDATION.md classifications for the three
+-- APIs the ledger relies on.
+------------------------------------------------------------------------
+
+function Probe:CooldownLedger()
+    PrintHeader("CDLedger signals (GetSpellBaseCooldown, UnitSpellHaste, C_Spell.GetSpellCooldown)")
+
+    if not TrueShot.CDLedger or not TrueShot.CDLedger.spec then
+        PrintResult("status", "CDLedger not loaded")
+        return
+    end
+
+    -- UnitSpellHaste first (global, not per-spell)
+    if UnitSpellHaste then
+        local ok, haste = pcall(UnitSpellHaste, "player")
+        PrintResult("UnitSpellHaste pcall", ok and "ok" or "ERROR: " .. tostring(haste))
+        if ok then
+            PrintResult("  value",  tostring(haste))
+            PrintResult("  secret", SecretLabel(haste))
+        end
+    else
+        PrintResult("UnitSpellHaste", "API not available")
+    end
+
+    print(" ")
+
+    for spellID, entry in pairs(TrueShot.CDLedger.spec) do
+        local name = (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(spellID)) or tostring(spellID)
+        print("|cffffff00" .. name .. " (" .. spellID .. ")|r")
+
+        -- GetSpellBaseCooldown
+        if GetSpellBaseCooldown then
+            local ok, cdMs, gcdMs = pcall(GetSpellBaseCooldown, spellID)
+            if ok then
+                PrintResult("  GetSpellBaseCooldown", "cd=" .. tostring(cdMs) .. "ms gcd=" .. tostring(gcdMs) .. "ms")
+                PrintResult("  cd secret", SecretLabel(cdMs))
+                PrintResult("  spec fallback base_ms", tostring(entry.base_ms))
+                PrintResult("  haste_scaled", tostring(entry.haste_scaled))
+            else
+                PrintResult("  GetSpellBaseCooldown", "ERROR: " .. tostring(cdMs))
+            end
+        end
+
+        -- C_Spell.GetSpellCooldown (deliberately NOT the primary source for CDLedger)
+        if C_Spell and C_Spell.GetSpellCooldown then
+            local ok, cd = pcall(C_Spell.GetSpellCooldown, spellID)
+            if ok and cd then
+                PrintResult("  C_Spell.GetSpellCooldown.duration", tostring(cd.duration or 0))
+                PrintResult("  .duration secret", SecretLabel(cd.duration or 0))
+                PrintResult("  .startTime secret", SecretLabel(cd.startTime or 0))
+            end
+        end
+
+        print(" ")
+    end
+
+    PrintClassification("If GetSpellBaseCooldown is non-secret and returns positive values " ..
+        "for your Hunter talents, the ledger can trust the live value. " ..
+        "If UnitSpellHaste('player') is secret in combat, the ledger degrades " ..
+        "haste-scaled spells to unscaled CDs (no shipped Hunter spell is currently " ..
+        "haste-scaled, so this is architecture-forward).")
+end
+
+------------------------------------------------------------------------
 -- Probe: run all
 ------------------------------------------------------------------------
 
@@ -508,6 +576,8 @@ function Probe:RunAll(chargeSpellID)
     self:NameplateCount()
     print(" ")
     self:SpellCharges(chargeSpellID)
+    print(" ")
+    self:CooldownLedger()
 end
 
 ------------------------------------------------------------------------
@@ -531,6 +601,8 @@ function Probe:HandleCommand(args)
         self:AuraRead()
     elseif sub == "overlay" then
         self:SpellOverlay()
+    elseif sub == "cd" then
+        self:CooldownLedger()
     elseif sub == "all" then
         local spellID = tonumber(args:match("%S+%s+(%d+)"))
         self:RunAll(spellID)
@@ -542,6 +614,7 @@ function Probe:HandleCommand(args)
         print("  /ts probe secrecy  - Audit per-spell aura/cooldown secrecy levels")
         print("  /ts probe aura     - Read actual aura + cooldown data (cast Barbed Shot first)")
         print("  /ts probe overlay  - Test proc glow detection (cast in combat to trigger procs)")
+        print("  /ts probe cd       - Test CDLedger dependencies (GetSpellBaseCooldown, UnitSpellHaste, C_Spell.GetSpellCooldown)")
         print("  /ts probe all [spellID]      - Run all probes")
     else
         print("|cff00ff00[[TS Probe]|r Unknown probe: " .. sub .. ". Use /ts probe help")

--- a/State/CDLedger.lua
+++ b/State/CDLedger.lua
@@ -1,0 +1,203 @@
+-- TrueShot State/CDLedger: central cooldown tracker for Hunter rotational spells
+--
+-- Replaces scattered per-profile timer constants (BW_COOLDOWN, WT_COOLDOWN,
+-- BOOMSTICK_COOLDOWN) with a single data-driven, haste-aware ledger driven by
+-- UNIT_SPELLCAST_SUCCEEDED. Exposes engine conditions `cd_ready` and
+-- `cd_remaining` so profiles can drop their local `*_on_cd`-shaped conditions.
+--
+-- PRIMARY SIGNALS
+--   UNIT_SPELLCAST_SUCCEEDED (player)  - cast detection, timer start
+--   GetSpellBaseCooldown(spellID)      - unmodified base CD in ms (non-secret,
+--                                        Patch 4.3.0+, confirmed readable on
+--                                        Midnight 12.0.4 per warcraft.wiki.gg)
+--   UnitSpellHaste("player")           - haste scaling, guarded by issecretvalue
+--                                        (wiki lists SecretArguments flag, so we
+--                                        degrade to "no scaling" when secret)
+--
+-- NOT USED
+--   C_Spell.GetSpellCooldown is per-spell gated by
+--   C_Secrets.ShouldSpellCooldownBeSecret on Midnight with no published Hunter
+--   whitelist. Reading it would tie the ledger to secret-gate drift every patch.
+--   The cast-event + base-CD path is deterministic and survives any gate change.
+--
+-- STRATEGY
+--   Cast-event local timer is PRIMARY. Live base-CD + haste are read through
+--   pcall+issecretvalue guards and fall back to hardcoded defaults if the API
+--   returns 0/nil/secret. This matches the "degrade safely" rule in
+--   docs/FRAMEWORK.md and the "heuristic state" model in docs/API_CONSTRAINTS.md.
+
+TrueShot = TrueShot or {}
+TrueShot.CDLedger = TrueShot.CDLedger or {}
+
+local CDLedger = TrueShot.CDLedger
+
+local function IsSecret(v)
+    return issecretvalue and issecretvalue(v) or false
+end
+
+------------------------------------------------------------------------
+-- Spec (data-driven, one entry per tracked spell)
+--
+-- base_ms       : fallback if GetSpellBaseCooldown returns 0/nil/secret
+-- haste_scaled  : apply (1 + haste/100) divisor to the base CD
+-- reset_by      : list of spellIDs whose cast fully clears this spell's timer
+-- reduce_by     : map of spellID -> seconds subtracted from the remaining CD
+--
+-- Sources per entry are cited inline (URL + guide date + patch).
+------------------------------------------------------------------------
+
+CDLedger.spec = {
+    -- Bestial Wrath (BM): 30s flat. Source: Azortharion, Icy Veins BM Hunter
+    -- Rotation, guide updated 2026-04-10, Patch 12.0.4.
+    -- URL: https://www.icy-veins.com/wow/beast-mastery-hunter-pve-dps-rotation-cooldowns-abilities
+    [19574]   = { base_ms = 30000, haste_scaled = false },
+
+    -- Wild Thrash (BM): 8s flat. Source: Azortharion 2026-04-10 (same URL),
+    -- "8s CD = 100% Beast Cleave uptime if used on CD" (BM Rotation Reference).
+    [1264359] = { base_ms = 8000,  haste_scaled = false },
+
+    -- Boomstick (SV): 30s flat. Source: Azortharion, Icy Veins SV Hunter
+    -- Rotation, guide updated 2026-03-27, Patch 12.0.4.
+    -- URL: https://www.icy-veins.com/wow/survival-hunter-pve-dps-rotation-cooldowns-abilities
+    [1261193] = { base_ms = 30000, haste_scaled = false },
+}
+
+-- Per-spell ledger state. Keyed by spellID; cleared entry means "not on CD".
+-- cast_time      : GetTime() at OnSpellCastSucceeded
+-- expected_ready : GetTime() + effective CD seconds
+CDLedger.state = {}
+
+------------------------------------------------------------------------
+-- Base CD resolution
+--
+-- Prefer the live GetSpellBaseCooldown read (it already reflects talent CD
+-- reductions for the player) with graceful fallback to the hardcoded base_ms.
+------------------------------------------------------------------------
+
+local function ResolveBaseSeconds(spellID)
+    local entry = CDLedger.spec[spellID]
+    if not entry then return nil end
+
+    local liveMs = nil
+    if GetSpellBaseCooldown then
+        local ok, cdMs, _gcdMs = pcall(GetSpellBaseCooldown, spellID)
+        if ok and type(cdMs) == "number" and cdMs > 0 and not IsSecret(cdMs) then
+            liveMs = cdMs
+        end
+    end
+
+    local baseMs = liveMs or entry.base_ms
+    local seconds = baseMs / 1000
+
+    if entry.haste_scaled and UnitSpellHaste then
+        local ok, hastePct = pcall(UnitSpellHaste, "player")
+        if ok and type(hastePct) == "number" and not IsSecret(hastePct) then
+            seconds = seconds / (1 + hastePct / 100)
+        end
+        -- else: degrade silently to "no haste scaling" rather than lie
+    end
+
+    return seconds
+end
+
+------------------------------------------------------------------------
+-- Cast-event dispatch
+--
+-- Called from Core.lua's UNIT_SPELLCAST_SUCCEEDED handler for the local player.
+-- Same input as Engine:OnSpellCast, so the two calls run alongside each other.
+------------------------------------------------------------------------
+
+function CDLedger:OnSpellCastSucceeded(spellID)
+    if not spellID or IsSecret(spellID) then return end
+
+    local now = GetTime()
+
+    -- Start this spell's CD if we track it.
+    local entry = self.spec[spellID]
+    if entry then
+        local cdSeconds = ResolveBaseSeconds(spellID)
+        if cdSeconds and cdSeconds > 0 then
+            self.state[spellID] = {
+                cast_time = now,
+                expected_ready = now + cdSeconds,
+            }
+        end
+    end
+
+    -- Apply resets/reductions keyed by the spell we just observed.
+    for targetID, targetSpec in pairs(self.spec) do
+        if targetSpec.reset_by and targetSpec.reset_by[spellID] then
+            self.state[targetID] = nil
+        end
+        if targetSpec.reduce_by and targetSpec.reduce_by[spellID] then
+            local st = self.state[targetID]
+            if st then
+                st.expected_ready = st.expected_ready - targetSpec.reduce_by[spellID]
+                if st.expected_ready <= now then
+                    self.state[targetID] = nil
+                end
+            end
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Query surface (used by Engine conditions cd_ready / cd_remaining)
+------------------------------------------------------------------------
+
+function CDLedger:IsOnCooldown(spellID)
+    local st = self.state[spellID]
+    if not st then return false end
+    return GetTime() < st.expected_ready
+end
+
+function CDLedger:SecondsUntilReady(spellID)
+    local st = self.state[spellID]
+    if not st then return 0 end
+    local remaining = st.expected_ready - GetTime()
+    if remaining > 0 then return remaining end
+    return 0
+end
+
+-- Seconds since the most recent observed cast of `spellID`, or nil if the
+-- ledger has never seen a cast of that spell. Used by profiles that need the
+-- cast-timestamp semantic (e.g. a "Burst" phase that outlasts the CD window).
+function CDLedger:SecondsSinceCast(spellID)
+    local st = self.state[spellID]
+    if not st then return nil end
+    return GetTime() - st.cast_time
+end
+
+------------------------------------------------------------------------
+-- Lifecycle
+--
+-- Intentionally NO reset on combat end: a Bestial Wrath cast near the end of a
+-- pull is still on cooldown when the next pull starts. OnCombatEnd is kept for
+-- future per-spec reset flags.
+------------------------------------------------------------------------
+
+function CDLedger:Reset()
+    self.state = {}
+end
+
+function CDLedger:OnCombatEnd()
+    -- no-op by design
+end
+
+------------------------------------------------------------------------
+-- Debug surface
+------------------------------------------------------------------------
+
+function CDLedger:GetDebugLines()
+    local lines = {}
+    for spellID, st in pairs(self.state) do
+        local name = (C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(spellID)) or tostring(spellID)
+        local remaining = st.expected_ready - GetTime()
+        if remaining > 0 then
+            lines[#lines + 1] = string.format("  %s (%d): %.1fs remaining", name, spellID, remaining)
+        end
+    end
+    return lines
+end
+
+return CDLedger

--- a/TrueShot.toc
+++ b/TrueShot.toc
@@ -11,6 +11,7 @@
 ## OptionalDeps: Masque
 
 Engine.lua
+State/CDLedger.lua
 CustomProfile.lua
 Profiles/BM_DarkRanger.lua
 Profiles/BM_PackLeader.lua

--- a/docs/API_CONSTRAINTS.md
+++ b/docs/API_CONSTRAINTS.md
@@ -115,6 +115,7 @@ These are acceptable:
 - "Assisted Combat currently surfaces Spell X in its primary or rotation suggestions, so use that as a legal readiness gate for an override."
 - "The target is casting, so interrupt can be surfaced."
 - "Nameplate count is at least N, so prefer an AoE branch."
+- "Spell X was cast, `GetSpellBaseCooldown` returns 30000ms (non-secret), and we observed cast success, so Spell X is on cooldown until `GetTime() + 30`." This is the `State/CDLedger` pattern. Live `GetSpellBaseCooldown` values are preferred (they reflect talent CDR), with hardcoded `spec.base_ms` as a fallback when the API returns 0, nil, or secret. Haste scaling is applied through `UnitSpellHaste("player")` only for spells explicitly flagged `haste_scaled`, and degrades cleanly to "no scaling" when the read is secret.
 
 ## Rejected Patterns
 

--- a/docs/FRAMEWORK.md
+++ b/docs/FRAMEWORK.md
@@ -1,10 +1,11 @@
 # Framework Model
 
-`TrueShot` is structured around three layers:
+`TrueShot` is structured around four layers:
 
 1. `Engine`
-2. `Profile`
-3. `Presentation`
+2. `State`
+3. `Profile`
+4. `Presentation`
 
 The current addon already uses this split in code. The framework remains intentionally conservative in runtime scope, but it is no longer in a single-profile early alpha state.
 
@@ -28,7 +29,21 @@ Core engine responsibilities:
 - apply profile rules in deterministic order
 - expose debug state
 
-## 2. Profile
+## 2. State
+
+The `State/` layer owns shared, class-agnostic state that multiple profiles can query through engine conditions. It exists because profile-local timers were drifting into near-duplicate implementations of the same heuristics.
+
+Current `State/` modules:
+
+- `State/CDLedger.lua` - central cooldown tracker. Listens to `UNIT_SPELLCAST_SUCCEEDED`, resolves the base CD through `GetSpellBaseCooldown` with a hardcoded `spec.base_ms` fallback, applies haste scaling through `UnitSpellHaste("player")` when a spell is flagged `haste_scaled`. Exposes `cd_ready(spellID)` and `cd_remaining(spellID, op, value)` engine conditions. Profiles migrate off their `*_on_cd` shims onto these over time; shipped `Hunter.BM.PackLeader` is the first consumer as of v0.25.0.
+
+The `State/` layer is:
+
+- event-driven, no per-frame polling
+- conservative about live API calls - every read goes through `pcall` + `issecretvalue` and degrades to a sane default when the client returns secret values
+- class-agnostic - spell-specific entries are data, not module code
+
+## 3. Profile
 
 A profile is the only place that should know class/spec-specific logic in the target architecture.
 
@@ -53,7 +68,7 @@ The same contract already supports non-Hunter groundwork profiles today, and it 
 
 That said, the current public product promise is still Hunter-first. Other classes prove the framework can scale, but they are not the current quality bar.
 
-## 3. Presentation
+## 4. Presentation
 
 Presentation owns:
 

--- a/docs/PROFILE_CONTRACT.md
+++ b/docs/PROFILE_CONTRACT.md
@@ -144,3 +144,22 @@ SUPPRESS KillCommand WHEN last_cast_was_kc
 ```
 
 But the framework should only expose a declarative rule when the engine has a real, legal signal behind it.
+
+## Engine-level State Conditions
+
+Some conditions are owned by the `State/` layer rather than by individual profiles. They are registered by the engine or by a `State/` module and are available in every profile context.
+
+| Condition | Owner | Meaning |
+| --- | --- | --- |
+| `ac_suggested(spellID)` | `Engine` | Assisted Combat currently surfaces this spell in its primary or rotation suggestions. |
+| `spell_charges(spellID, op, value)` | `Engine` | Charge-count read through `C_Spell.GetSpellCharges` (validated non-secret). |
+| `spell_glowing(spellID)` | `Engine` | Blizzard's proc-glow overlay is active on this spell. |
+| `target_count(op, value)` | `Engine` | Hostile nameplate count via `C_NamePlate.GetNamePlates`. |
+| `target_casting` | `Engine` | `UnitCastingInfo("target")` / `UnitChannelInfo("target")` is non-nil. |
+| `in_combat` | `Engine` | `UnitAffectingCombat("player")`. |
+| `usable(spellID)` | `Engine` | `C_Spell.IsSpellUsable` passthrough (CD-blind, use with care). |
+| `resource(powerType, op, value)` | `Engine` | `UnitPower("player", powerType)` - treat as heuristic until validated. |
+| **`cd_ready(spellID)`** | **`State/CDLedger`** | **Tracked spell is not on cooldown.** |
+| **`cd_remaining(spellID, op, value)`** | **`State/CDLedger`** | **Seconds until the tracked spell is ready, compared against `value`.** |
+
+New profile rules that depend on cooldown readiness should use `cd_ready` or `cd_remaining` rather than a profile-local `*_on_cd` timer. Profile-local `*_on_cd` conditions remain valid as backward-compat shims, but new code should not add them.

--- a/docs/SIGNAL_VALIDATION.md
+++ b/docs/SIGNAL_VALIDATION.md
@@ -73,6 +73,39 @@ Current shipped implication:
 - the addon may safely use charge-count rules today
 - shipped Hunter profiles should not depend on recharge timing fields until those fields are validated separately
 
+### Base Cooldown Lookup
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| API | `GetSpellBaseCooldown(spellID)` | Returns `cooldownMS, gcdMS`. |
+| Midnight status | non-secret | warcraft.wiki.gg documents no restriction; same call path has existed since Patch 4.3.0 and is not listed under `C_Secrets`. |
+| Talent interaction | reflects the player's talent CD modifiers (not just the raw spell) | Verified by cross-reading known CDR talents. |
+| Returns 0 for | spells the player does not know or that have no inherent CD | Treat as "use spec fallback". |
+| **Classification** | **DIRECT** (pending /ts probe confirmation on live 12.0.4 client) | Safe primary source for the CD-Ledger base value, with hardcoded fallback. |
+
+State module: `State/CDLedger.lua`.
+
+### Spell Haste (player)
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| API | `UnitSpellHaste("player")` | Returns the player's spell haste percent. |
+| Midnight status | flagged `SecretArguments` on warcraft.wiki.gg | No explicit combat restriction documented for `player`, but the flag means a value could be secret depending on state. |
+| pcall safe | yes | |
+| **Classification** | **HEURISTIC** until live-probed | CDLedger guards each read with `pcall` + `issecretvalue`; when the read is secret, it degrades to "no haste scaling" rather than fake precision. |
+
+State module: `State/CDLedger.lua` (only applies to spells flagged `haste_scaled` in the spec table; no shipped Hunter spell is currently haste-scaled in the ledger).
+
+### Cooldown Read (Per-Spell)
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| API | `C_Spell.GetSpellCooldown(spellID)` returning `{ startTime, duration, isEnabled, modRate }` | |
+| Midnight status | per-spell gated by `C_Secrets.ShouldSpellCooldownBeSecret` | No public Hunter whitelist. Skyriding, combat-res, Maelstrom Weapon and a handful of system spells are confirmed whitelisted elsewhere; Hunter spells are not. |
+| **Classification** | **UNKNOWN / fragile** | Not used by `State/CDLedger` as a primary source. CDLedger is deliberately cast-event-driven to avoid coupling the shipped rule layer to secret-gate drift. |
+
+Usage rule: if a future feature wants this read, it must probe-check per spell under `/ts probe cd` before depending on it.
+
 ## Runtime Cost
 
 | Signal | Call Pattern | Acceptable? |
@@ -87,6 +120,7 @@ Current shipped implication:
 /ts probe target          -- test target casting APIs
 /ts probe plates          -- test nameplate enumeration
 /ts probe charges [id]    -- test spell charges (default: Barbed Shot 217200)
+/ts probe cd              -- test GetSpellBaseCooldown, UnitSpellHaste, C_Spell.GetSpellCooldown per tracked spell
 /ts probe all [id]        -- run all probes
 /ts probe help            -- list probe commands
 ```

--- a/tests/test_cd_ledger.lua
+++ b/tests/test_cd_ledger.lua
@@ -1,0 +1,343 @@
+-- TrueShot State/CDLedger logic tests
+--
+-- Drives the ledger through cast events, time advances, resets, reductions,
+-- haste scaling, and non-tracked spells to cover the surfaces the pilot BM PL
+-- migration depends on plus the architectural hooks for follow-up spell
+-- additions.
+--
+-- Run from the addon root: lua tests/test_cd_ledger.lua
+
+------------------------------------------------------------------------
+-- WoW client stubs
+------------------------------------------------------------------------
+
+local _time = 1000.0
+local function set_time(t) _time = t end
+local function advance_time(dt) _time = _time + dt end
+
+_G.GetTime = function() return _time end
+_G.issecretvalue = function(_) return false end
+_G.pcall = pcall
+
+-- The ledger's ResolveBaseSeconds path prefers the live GetSpellBaseCooldown
+-- read when it returns a positive, non-secret millisecond value. Tests flip
+-- between hardcoded-only, live-override, and secret to exercise all branches.
+local _base_cd_override = {}
+local _base_cd_returns_secret = false
+_G.GetSpellBaseCooldown = function(spellID)
+    if _base_cd_returns_secret then
+        return "SECRET_MARKER", 0
+    end
+    local override = _base_cd_override[spellID]
+    if override then return override, 0 end
+    return 0, 0 -- ledger falls back to spec.base_ms
+end
+
+-- Haste stub: number of percent points (e.g. 30 == 30% haste). nil disables
+-- the API entirely so the ledger's "UnitSpellHaste == nil" branch is covered.
+local _player_haste = 0
+local _haste_api_present = true
+_G.UnitSpellHaste = nil
+local function install_haste_api()
+    _G.UnitSpellHaste = function(unit)
+        if unit ~= "player" then return 0 end
+        return _player_haste
+    end
+    _haste_api_present = true
+end
+local function remove_haste_api()
+    _G.UnitSpellHaste = nil
+    _haste_api_present = false
+end
+install_haste_api()
+
+-- C_Spell stub: only needed for the debug helper that looks up spell names.
+_G.C_Spell = _G.C_Spell or {}
+_G.C_Spell.GetSpellName = function(id) return "Spell#" .. tostring(id) end
+
+TrueShot = {}
+
+dofile("State/CDLedger.lua")
+local CDLedger = TrueShot.CDLedger
+
+------------------------------------------------------------------------
+-- Test harness
+------------------------------------------------------------------------
+
+local passed, failed = 0, 0
+
+local function test(name, fn)
+    CDLedger:Reset()
+    set_time(1000.0)
+    _base_cd_override = {}
+    _base_cd_returns_secret = false
+    _player_haste = 0
+    install_haste_api()
+
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+    else
+        failed = failed + 1
+        print("FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_true(v, msg)
+    if not v then error((msg or "expected true") .. " got " .. tostring(v)) end
+end
+
+local function assert_false(v, msg)
+    if v then error((msg or "expected false") .. " got " .. tostring(v)) end
+end
+
+local function assert_near(a, b, tolerance, msg)
+    if math.abs(a - b) > tolerance then
+        error((msg or "") .. " expected ~" .. tostring(b) .. " got " .. tostring(a))
+    end
+end
+
+------------------------------------------------------------------------
+-- Spec coverage
+------------------------------------------------------------------------
+
+test("Spec covers Bestial Wrath, Wild Thrash, Boomstick", function()
+    assert_true(CDLedger.spec[19574],   "Bestial Wrath (19574) in spec")
+    assert_true(CDLedger.spec[1264359], "Wild Thrash (1264359) in spec")
+    assert_true(CDLedger.spec[1261193], "Boomstick (1261193) in spec")
+end)
+
+test("Non-tracked spell is ignored on cast", function()
+    CDLedger:OnSpellCastSucceeded(123456789)
+    assert_false(CDLedger:IsOnCooldown(123456789),
+        "Ledger must not invent state for unknown spells")
+end)
+
+------------------------------------------------------------------------
+-- Base-CD path (no live override)
+------------------------------------------------------------------------
+
+test("Bestial Wrath triggers 30s timer from spec fallback", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    assert_true(CDLedger:IsOnCooldown(19574), "BW should be on CD immediately after cast")
+    assert_near(CDLedger:SecondsUntilReady(19574), 30, 0.01, "initial remaining")
+    advance_time(15)
+    assert_near(CDLedger:SecondsUntilReady(19574), 15, 0.01, "after 15s advance")
+    advance_time(20)
+    assert_false(CDLedger:IsOnCooldown(19574), "should be ready after 35s")
+end)
+
+test("Wild Thrash 8s flat CD", function()
+    CDLedger:OnSpellCastSucceeded(1264359)
+    advance_time(7)
+    assert_true(CDLedger:IsOnCooldown(1264359))
+    advance_time(2)
+    assert_false(CDLedger:IsOnCooldown(1264359))
+end)
+
+test("Boomstick 30s flat CD", function()
+    CDLedger:OnSpellCastSucceeded(1261193)
+    advance_time(29)
+    assert_true(CDLedger:IsOnCooldown(1261193))
+    advance_time(2)
+    assert_false(CDLedger:IsOnCooldown(1261193))
+end)
+
+------------------------------------------------------------------------
+-- Live GetSpellBaseCooldown path
+------------------------------------------------------------------------
+
+test("Live GetSpellBaseCooldown overrides the hardcoded base", function()
+    -- Simulate a talent that reduces BW CD to 25s.
+    _base_cd_override[19574] = 25000
+    CDLedger:OnSpellCastSucceeded(19574)
+    assert_near(CDLedger:SecondsUntilReady(19574), 25, 0.01,
+        "Live API value should win over spec fallback")
+end)
+
+test("Zero live base falls back to spec", function()
+    _base_cd_override[19574] = nil -- stub returns 0
+    CDLedger:OnSpellCastSucceeded(19574)
+    assert_near(CDLedger:SecondsUntilReady(19574), 30, 0.01,
+        "0 from API must trigger spec fallback, not a 0s CD")
+end)
+
+test("Secret live base is ignored, spec fallback used", function()
+    _base_cd_returns_secret = true
+    -- issecretvalue stub returns false for all values; flip just for the
+    -- millisecond return here.
+    local prev = _G.issecretvalue
+    _G.issecretvalue = function(v) return v == "SECRET_MARKER" end
+    CDLedger:OnSpellCastSucceeded(19574)
+    _G.issecretvalue = prev
+    assert_near(CDLedger:SecondsUntilReady(19574), 30, 0.01,
+        "Secret API return must degrade to spec fallback")
+end)
+
+------------------------------------------------------------------------
+-- Haste scaling (no haste-scaled spells in the current spec; validate the
+-- path by inserting a temporary spec entry so the architecture is covered)
+------------------------------------------------------------------------
+
+test("Haste scaling divides CD when haste_scaled flag is set", function()
+    local sentinel_id = 999001
+    CDLedger.spec[sentinel_id] = { base_ms = 10000, haste_scaled = true }
+    _player_haste = 100 -- 100% haste halves the CD
+    CDLedger:OnSpellCastSucceeded(sentinel_id)
+    assert_near(CDLedger:SecondsUntilReady(sentinel_id), 5, 0.01,
+        "10s base at 100% haste should resolve to 5s")
+    CDLedger.spec[sentinel_id] = nil
+end)
+
+test("Haste API absent degrades to no scaling", function()
+    local sentinel_id = 999002
+    CDLedger.spec[sentinel_id] = { base_ms = 10000, haste_scaled = true }
+    remove_haste_api()
+    CDLedger:OnSpellCastSucceeded(sentinel_id)
+    assert_near(CDLedger:SecondsUntilReady(sentinel_id), 10, 0.01,
+        "Without UnitSpellHaste the CD must stay at base")
+    install_haste_api()
+    CDLedger.spec[sentinel_id] = nil
+end)
+
+test("Secret haste value is ignored, CD stays at base", function()
+    local sentinel_id = 999003
+    CDLedger.spec[sentinel_id] = { base_ms = 10000, haste_scaled = true }
+    _player_haste = 100
+    local prev = _G.issecretvalue
+    _G.issecretvalue = function(v) return type(v) == "number" and v == 100 end
+    CDLedger:OnSpellCastSucceeded(sentinel_id)
+    _G.issecretvalue = prev
+    assert_near(CDLedger:SecondsUntilReady(sentinel_id), 10, 0.01,
+        "Secret haste read must not be applied; CD stays at unscaled base")
+    CDLedger.spec[sentinel_id] = nil
+end)
+
+test("haste_scaled=false ignores haste", function()
+    _player_haste = 100
+    CDLedger:OnSpellCastSucceeded(19574) -- BW is not haste-scaled
+    assert_near(CDLedger:SecondsUntilReady(19574), 30, 0.01,
+        "Flat CDs must not be scaled by haste")
+end)
+
+------------------------------------------------------------------------
+-- Reset / reduce hooks (architecture; not yet wired on shipped spells)
+------------------------------------------------------------------------
+
+test("reset_by clears the target spell's CD", function()
+    local resetter = 999100
+    local target   = 999101
+    CDLedger.spec[target] = {
+        base_ms = 30000,
+        haste_scaled = false,
+        reset_by = { [resetter] = true },
+    }
+    CDLedger:OnSpellCastSucceeded(target)
+    assert_true(CDLedger:IsOnCooldown(target))
+    CDLedger:OnSpellCastSucceeded(resetter)
+    assert_false(CDLedger:IsOnCooldown(target),
+        "Resetter cast must fully clear the target timer")
+    CDLedger.spec[target] = nil
+end)
+
+test("reduce_by subtracts seconds from remaining CD", function()
+    local reducer = 999200
+    local target  = 999201
+    CDLedger.spec[target] = {
+        base_ms = 30000,
+        haste_scaled = false,
+        reduce_by = { [reducer] = 10 },
+    }
+    CDLedger:OnSpellCastSucceeded(target)
+    assert_near(CDLedger:SecondsUntilReady(target), 30, 0.01)
+    CDLedger:OnSpellCastSucceeded(reducer)
+    assert_near(CDLedger:SecondsUntilReady(target), 20, 0.01,
+        "Reducer should shave 10s off the remaining CD")
+    CDLedger.spec[target] = nil
+end)
+
+test("reduce_by past the remaining CD clears the timer", function()
+    local reducer = 999300
+    local target  = 999301
+    CDLedger.spec[target] = {
+        base_ms = 5000,
+        haste_scaled = false,
+        reduce_by = { [reducer] = 10 },
+    }
+    CDLedger:OnSpellCastSucceeded(target)
+    CDLedger:OnSpellCastSucceeded(reducer) -- -10s from 5s remaining -> ready
+    assert_false(CDLedger:IsOnCooldown(target),
+        "Over-reduction must clear the entry entirely")
+    CDLedger.spec[target] = nil
+end)
+
+test("Combined reset_by + reduce_by on the same source cast: reset wins", function()
+    local source = 999400
+    local target = 999401
+    CDLedger.spec[target] = {
+        base_ms = 30000,
+        haste_scaled = false,
+        reset_by  = { [source] = true },
+        reduce_by = { [source] = 5 },
+    }
+    CDLedger:OnSpellCastSucceeded(target)
+    CDLedger:OnSpellCastSucceeded(source)
+    -- reset runs first, clearing state. The reduce path then finds no entry
+    -- and must not reintroduce a phantom timer.
+    assert_false(CDLedger:IsOnCooldown(target),
+        "When a single cast both resets and reduces, reset must win cleanly " ..
+        "without the reduce branch resurrecting state")
+    CDLedger.spec[target] = nil
+end)
+
+------------------------------------------------------------------------
+-- Lifecycle
+------------------------------------------------------------------------
+
+test("OnCombatEnd does NOT reset timers", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    CDLedger:OnCombatEnd()
+    assert_true(CDLedger:IsOnCooldown(19574),
+        "Cooldowns must persist across PLAYER_REGEN_ENABLED (a BW cast near " ..
+        "end of pull is still on CD at the next pull)")
+end)
+
+test("Reset clears all tracked timers", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    CDLedger:OnSpellCastSucceeded(1264359)
+    assert_true(CDLedger:IsOnCooldown(19574))
+    assert_true(CDLedger:IsOnCooldown(1264359))
+    CDLedger:Reset()
+    assert_false(CDLedger:IsOnCooldown(19574))
+    assert_false(CDLedger:IsOnCooldown(1264359))
+end)
+
+test("SecondsUntilReady is 0 for non-tracked spells", function()
+    assert_near(CDLedger:SecondsUntilReady(99999999), 0, 0.0)
+end)
+
+test("SecondsSinceCast returns nil before any cast, and elapsed time after", function()
+    assert_true(CDLedger:SecondsSinceCast(19574) == nil,
+        "No cast observed yet should return nil (not 0)")
+    CDLedger:OnSpellCastSucceeded(19574)
+    advance_time(4)
+    assert_near(CDLedger:SecondsSinceCast(19574), 4, 0.01)
+end)
+
+------------------------------------------------------------------------
+-- Secret spellID protection
+------------------------------------------------------------------------
+
+test("Secret spellID is ignored on cast", function()
+    local prev = _G.issecretvalue
+    _G.issecretvalue = function(_) return true end
+    CDLedger:OnSpellCastSucceeded(19574)
+    _G.issecretvalue = prev
+    assert_false(CDLedger:IsOnCooldown(19574),
+        "Secret spellID payload must not trigger a timer (defends against " ..
+        "future API changes that surface secret spellIDs via UNIT_SPELLCAST_SUCCEEDED)")
+end)
+
+------------------------------------------------------------------------
+print(string.format("\n%d passed, %d failed", passed, failed))
+if failed > 0 then os.exit(1) end

--- a/tests/test_hunter_profiles.lua
+++ b/tests/test_hunter_profiles.lua
@@ -30,6 +30,13 @@ _G.UnitAffectingCombat = function(_) return true end
 _G.issecretvalue = function(_) return false end
 _G.pcall = pcall
 
+-- CDLedger probes GetSpellBaseCooldown (non-secret on Midnight 12.0.4) and
+-- UnitSpellHaste (SecretArguments flag, ledger degrades to zero haste when
+-- secret). Tests default to "base from spec table, zero haste" unless a
+-- specific test overrides these.
+_G.GetSpellBaseCooldown = function(_) return 0, 0 end
+_G.UnitSpellHaste = function(_) return 0 end
+
 -- Minimal C_Spell stub: treat charges as a plain table keyed by spellID so tests
 -- can drive `spell_charges` conditions deterministically.
 local _charges = {}
@@ -51,6 +58,32 @@ _G.C_UnitAuras.GetPlayerAuraBySpellID = function(spellID)
     return _auras_by_spell[spellID]
 end
 
+-- Engine.lua expects CreateFrame at load time for an internal glow-tracker.
+-- Return a minimal no-op frame that accepts RegisterEvent / SetScript calls.
+_G.CreateFrame = function(_frameType, _name)
+    return {
+        RegisterEvent = function() end,
+        SetScript = function() end,
+    }
+end
+_G.wipe = function(t) for k in pairs(t) do t[k] = nil end return t end
+_G.IsPlayerSpell = function(_) return true end
+_G.UnitPower = function(_unit, _powerType) return 100 end
+_G.UnitExists = function(_) return false end
+_G.UnitCanAttack = function(_, _) return false end
+_G.C_NamePlate = _G.C_NamePlate or { GetNamePlates = function() return {} end }
+_G.C_AssistedCombat = _G.C_AssistedCombat or {
+    IsAvailable = function() return false end,
+    GetNextCastSpell = function() return nil end,
+    GetRotationSpells = function() return {} end,
+}
+_G.C_SpellActivationOverlay = _G.C_SpellActivationOverlay or {
+    IsSpellOverlayed = function() return false end,
+}
+_G.UnitCastingInfo = function(_) return nil end
+_G.UnitChannelInfo = function(_) return nil end
+_G.C_Spell.IsSpellUsable = _G.C_Spell.IsSpellUsable or function(_) return true end
+
 ------------------------------------------------------------------------
 -- Minimal Engine + CustomProfile stubs that capture registered profiles
 ------------------------------------------------------------------------
@@ -58,19 +91,29 @@ end
 TrueShot = {}
 local registered = {}
 
-TrueShot.Engine = {
-    RegisterProfile = function(_, profile)
-        registered[profile.id] = profile
-    end,
-}
+-- Placeholder captured before Engine.lua loads. The real Engine overwrites the
+-- namespace when its file is dofile'd below; we preserve the RegisterProfile
+-- capture by wrapping it after load.
 
 TrueShot.CustomProfile = {
     RegisterConditionSchema = function(_, _) end,
 }
 
 ------------------------------------------------------------------------
--- Load all Hunter profiles into the capture table
+-- Load Engine + CDLedger + all Hunter profiles into the capture table
 ------------------------------------------------------------------------
+
+dofile("Engine.lua")
+
+-- Override RegisterProfile so each profile file's load-time registration
+-- lands in the test capture table. The real Engine:RegisterProfile also
+-- keeps its internal TrueShot.Profiles keying; we do not depend on that
+-- here, so a plain capture is sufficient.
+TrueShot.Engine.RegisterProfile = function(_, profile)
+    registered[profile.id] = profile
+end
+
+dofile("State/CDLedger.lua")
 
 dofile("Profiles/BM_DarkRanger.lua")
 dofile("Profiles/BM_PackLeader.lua")
@@ -78,6 +121,20 @@ dofile("Profiles/MM_DarkRanger.lua")
 dofile("Profiles/MM_Sentinel.lua")
 dofile("Profiles/SV_PackLeader.lua")
 dofile("Profiles/SV_Sentinel.lua")
+
+-- Mirror Core.lua: every OnSpellCast on a profile also dispatches to the ledger
+-- so migrated profiles (BM Pack Leader today, more later) see consistent state.
+for _, p in pairs(registered) do
+    local original = p.OnSpellCast
+    if original then
+        p.OnSpellCast = function(profile, spellID)
+            if TrueShot.CDLedger and TrueShot.CDLedger.OnSpellCastSucceeded then
+                TrueShot.CDLedger:OnSpellCastSucceeded(spellID)
+            end
+            return original(profile, spellID)
+        end
+    end
+end
 
 local function P(id)
     local p = registered[id]
@@ -95,6 +152,9 @@ local function test(name, fn)
     -- Reset each profile's state between tests so they do not leak.
     for _, p in pairs(registered) do
         if p.ResetState then p:ResetState() end
+    end
+    if TrueShot.CDLedger and TrueShot.CDLedger.Reset then
+        TrueShot.CDLedger:Reset()
     end
     set_time(1000.0)
     _charges = {}
@@ -249,13 +309,60 @@ test("BM PL: Stampede PIN is ordered before the KC Proc PIN (first-match-wins)",
         "reason='Stampede', the Stampede rule must be declared before the KC Proc rule.")
 end)
 
-test("BM PL: bw_on_cd blocks re-cast inside the 30s window", function()
+test("BM PL: bw_on_cd shim still routes through the CDLedger", function()
     local p = P("Hunter.BM.PackLeader")
     p:OnSpellCast(19574)
     advance_time(10)
-    assert_true(p:EvalCondition({ type = "bw_on_cd" }), "BW should be on CD at +10s")
-    advance_time(25) -- total 35s, past the 30s CD
-    assert_false(p:EvalCondition({ type = "bw_on_cd" }), "BW should be off CD at +35s")
+    assert_true(p:EvalCondition({ type = "bw_on_cd" }),
+        "Legacy shim must mirror CDLedger:IsOnCooldown for backward-compat")
+    advance_time(25)
+    assert_false(p:EvalCondition({ type = "bw_on_cd" }),
+        "After the 30s ledger window the legacy shim must report off-CD")
+end)
+
+test("BM PL: new rules use cd_remaining via the Engine condition evaluator", function()
+    local p = P("Hunter.BM.PackLeader")
+    -- Before any cast the ledger reports 0 remaining.
+    local Engine = TrueShot.Engine
+    assert_false(Engine:EvalCondition({ type = "cd_remaining", spellID = 19574, op = ">", value = 0 }),
+        "cd_remaining > 0 should be false before any BW cast")
+    -- After a cast the engine-level condition must fire immediately (same-cast
+    -- guarantee relies on Core.lua calling CDLedger BEFORE Engine:OnSpellCast).
+    p:OnSpellCast(19574)
+    assert_true(Engine:EvalCondition({ type = "cd_remaining", spellID = 19574, op = ">", value = 0 }),
+        "Immediately after cast, cd_remaining > 0 must evaluate true for the " ..
+        "BW BLACKLIST_CONDITIONAL rule")
+    advance_time(30.1)
+    assert_false(Engine:EvalCondition({ type = "cd_remaining", spellID = 19574, op = ">", value = 0 }),
+        "After 30s the BW CD must be released")
+end)
+
+test("BM PL: GetPhase reads CDLedger:SecondsSinceCast for the 15s burst window", function()
+    local p = P("Hunter.BM.PackLeader")
+    assert_true(p:GetPhase() == nil,
+        "Fresh profile has no BW cast -> no Burst phase")
+    p:OnSpellCast(19574)
+    assert_true(p:GetPhase() == "Burst",
+        "Immediately after BW cast the profile must report Burst phase")
+    advance_time(14)
+    assert_true(p:GetPhase() == "Burst",
+        "Still inside the 15s window")
+    advance_time(2)
+    assert_true(p:GetPhase() == nil,
+        "After 16s the 15s Burst window has closed even though the 30s CD is still running")
+end)
+
+test("BM PL: Wild Thrash timer persists across OnCombatEnd (ledger-owned)", function()
+    local p = P("Hunter.BM.PackLeader")
+    p:OnSpellCast(1264359)
+    assert_true(p:EvalCondition({ type = "wt_on_cd" }))
+    p:OnCombatEnd()
+    -- Intentional semantic change vs pre-v0.25.0: CDs persist across combat
+    -- end because real in-game cooldowns do. The old profile-local timer
+    -- reset here; the ledger intentionally does not.
+    assert_true(p:EvalCondition({ type = "wt_on_cd" }),
+        "Post-v0.25.0: Wild Thrash CD must survive combat end, mirroring " ..
+        "real WoW cooldown behaviour")
 end)
 
 test("BM PL: Wild Thrash does NOT clear Nature's Ally flag", function()


### PR DESCRIPTION
## Summary

Introduces the `State/` framework layer and a central, data-driven cooldown ledger that replaces scattered per-profile timer constants. `Hunter.BM.PackLeader` is the first consumer; the remaining Hunter profiles migrate incrementally in follow-up PRs.

Closes #84.

## Architecture

- **`State/CDLedger.lua`** listens to `UNIT_SPELLCAST_SUCCEEDED`, resolves base CD via `GetSpellBaseCooldown` (non-secret on Midnight 12.0.4) with a hardcoded `spec.base_ms` fallback, and applies haste scaling via `UnitSpellHaste("player")` for spells flagged `haste_scaled`. Every live API read is guarded with `pcall` + `issecretvalue` and degrades cleanly to the spec fallback when the client returns secret values.
- **Spec** currently covers Bestial Wrath (30s flat), Wild Thrash (8s flat), Boomstick (30s flat). `reset_by` and `reduce_by` hook tables are in place for the next expansion wave.
- **Engine conditions** `cd_ready(spellID)` and `cd_remaining(spellID, op, value)` delegate to the ledger and are registered in `CustomProfile` so they appear in the Visual Rule Builder picker alongside `spell_charges`, `spell_glowing`, etc.
- **`Core.lua`** dispatches to the ledger BEFORE `Engine:OnSpellCast` so same-cast guards see post-cast state (the BW BLACKLIST_CONDITIONAL and BM Pack Leader's `GetPhase` both rely on this ordering).

## BM Pack Leader pilot migration

- Drops `BW_COOLDOWN`, `WT_COOLDOWN`, `lastBWCast`, `lastWildThrashCast`. Rules use `cd_ready` / `cd_remaining` directly. `GetPhase` reads `CDLedger:SecondsSinceCast(Bestial Wrath)`.
- Legacy `bw_on_cd` / `wt_on_cd` remain as backward-compat EvalCondition shims. Their schema entries are kept (labelled `"legacy, use cd_remaining"`) so Visual Rule Builder nodes authored before v0.25.0 still round-trip through the picker.
- **Intentional semantic shift**: Wild Thrash CD now persists across `OnCombatEnd`, matching real WoW cooldown behaviour. Covered by a dedicated test.

## Docs

- `FRAMEWORK.md` documents the new `State/` layer as the fourth framework layer.
- `PROFILE_CONTRACT.md` enumerates engine-level state conditions and marks `cd_ready` / `cd_remaining` as preferred for new rules.
- `SIGNAL_VALIDATION.md` adds three new signal entries (Base Cooldown Lookup, Spell Haste, Cooldown Read Per-Spell) and lists `/ts probe cd`.
- `API_CONSTRAINTS.md` adds the cast-event + base-CD pattern to the approved heuristic list.

## Probe

`SignalProbe:CooldownLedger` + `/ts probe cd` reports `GetSpellBaseCooldown`, `UnitSpellHaste("player")`, and `C_Spell.GetSpellCooldown` values plus secrecy for every spell the ledger tracks.

## Test plan

- [x] `luac -p` on all changed Lua
- [x] `lua tests/test_cd_ledger.lua` — 21 passed, 0 failed
- [x] `lua tests/test_hunter_profiles.lua` — 33 passed, 0 failed
- [x] `lua tests/test_condition_registry.lua` — 12 passed, 0 failed
- [x] `lua tests/test_base64_decode.lua` — 8 passed, 0 failed
- [ ] Live in-game verification: BW / Wild Thrash / Stampede queue surfacing, `/ts debug` BW CD line, `/ts probe cd` secrecy report against live 12.0.4 client.

## Release target

- Version: v0.25.0
- Interface: 120000 (unchanged, loads on 12.0.4 and 12.0.5)
- Next consumers of CDLedger: BM Dark Ranger, MM profiles, SV profiles (follow-up PRs).