### PR TITLE
fix(mm): surface Trueshot in the queue without a prior Rapid Fire (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.25.1 - 2026-04-19
+
+### Fixed
+- **MM Trueshot no longer hidden from the queue when the opener did not start with Rapid Fire** (reported as [#89](https://github.com/itsDNNS/TrueShot/issues/89)). Both MM Dark Ranger and MM Sentinel profiles had a PIN rule that gated Trueshot on `rapid_fire_recent(3)`, which treated the Azortharion "Rapid Fire -> Trueshot -> Aimed Shot" sequence guidance as a hard precondition. Rapid Fire (~20s CD) and Trueshot (~2-3min CD) do not synchronise in practice, so the PIN never fired for players whose opener did not begin with a Rapid Fire, and Trueshot never surfaced in the queue. The PIN now triggers on `ac_suggested(Trueshot)` plus `in_combat`, so Trueshot is shown whenever Assisted Combat treats it as castable. The existing anti-overlap rules remain untouched (BLACKLIST_CONDITIONAL Trueshot on `volley_recent`, BLACKLIST_CONDITIONAL Volley on `trueshot_just_cast`), so the guide's "never back-to-back" Volley/Trueshot rule is still enforced. Sentinel trade-off: when Volley and Trueshot are simultaneously ready the queue now surfaces Trueshot first and the anti-overlap BLACKLIST on Volley then forces at least one intervening cast in typical play before Volley is shown again.
+- **Tests**: 8 new regression guards in `tests/test_hunter_profiles.lua` pin the post-fix rule shape for both MM profiles, including structural assertions that the Trueshot PIN condition does not walk into any `rapid_fire_recent` node, that the PIN fires under an AC-suggested Trueshot with no Rapid Fire history, and that both BLACKLIST anti-overlap rules stay in place. Full test suite now reports 41 Hunter + 21 CD ledger + 12 condition registry + 8 base64 = 82 passing.
+
 ## v0.25.0 - 2026-04-18
 
 ### Added

--- a/Profiles/MM_DarkRanger.lua
+++ b/Profiles/MM_DarkRanger.lua
@@ -143,21 +143,28 @@ local Profile = {
             },
         },
 
-        -- [src §Sequencing "Rapid Fire into Trueshot"] "Ideal setup follows
-        -- pattern: Rapid Fire -> Trueshot -> Aimed Shot." Pair the RF-recency
-        -- signal with the legal ac_suggested readiness gate for TS.
+        -- [src §ST #2 / issue #89] Trueshot is the MM major cooldown and the
+        -- guide's "main cooldown" priority. Surface it whenever AC treats the
+        -- spell as castable and we are in combat. The anti-overlap BLACKLIST
+        -- above already handles the Volley -> Trueshot Double Tap case; the
+        -- trueshot_just_cast BLACKLIST on Volley handles the reverse order,
+        -- so after a pinned Trueshot the queue naturally spends one filler
+        -- GCD before showing Volley again, matching the guide's
+        -- "one cast between Volley and Trueshot" rule.
+        --
+        -- The prior gate on rapid_fire_recent(3) was removed: it treated the
+        -- Azortharion "Rapid Fire -> Trueshot -> Aimed Shot" sequence as a
+        -- hard precondition, but RF (~20s CD) and Trueshot (~2-3min CD) do
+        -- not synchronise in practice, so the PIN never fired for players
+        -- who opened without Rapid Fire. Reported as issue #89.
         {
             type = "PIN",
             spellID = SPELLS.Trueshot,
-            reason = "Post-RF Window",
+            reason = "Trueshot",
             condition = {
                 type = "and",
                 left  = { type = "ac_suggested", spellID = SPELLS.Trueshot },
-                right = {
-                    type = "and",
-                    left  = { type = "rapid_fire_recent", seconds = 3 },
-                    right = { type = "not", inner = { type = "volley_recent", seconds = 2 } },
-                },
+                right = { type = "in_combat" },
             },
         },
 

--- a/Profiles/MM_Sentinel.lua
+++ b/Profiles/MM_Sentinel.lua
@@ -103,21 +103,38 @@ local Profile = {
             condition = { type = "trueshot_just_cast", seconds = 2 },
         },
 
-        -- [src §Sequencing "Rapid Fire into Trueshot"] "Ideal setup follows
-        -- pattern: Rapid Fire -> Trueshot -> Aimed Shot." Pair the RF-recency
-        -- signal with the legal ac_suggested readiness gate for TS.
+        -- [src §ST #2 / issue #89] Trueshot is MM's main cooldown. Surface it
+        -- whenever AC treats it as castable and we are in combat. The anti-
+        -- overlap BLACKLIST above handles Volley -> Trueshot, and the
+        -- trueshot_just_cast BLACKLIST on Volley handles the reverse, so
+        -- after a pinned Trueshot the queue naturally spends one filler GCD
+        -- before surfacing Volley again, matching the guide's "one cast
+        -- between Volley and Trueshot" rule.
+        --
+        -- The prior gate on rapid_fire_recent(3) was removed: it treated the
+        -- Azortharion "Rapid Fire -> Trueshot -> Aimed Shot" sequence as a
+        -- hard precondition for pinning Trueshot, but RF (~20s CD) and
+        -- Trueshot (~2-3min CD) do not synchronise in practice, so the PIN
+        -- never fired for players who opened without Rapid Fire. Reported as
+        -- issue #89.
+        --
+        -- Sentinel-specific trade-off: Azortharion lists Volley as ST #1 and
+        -- Trueshot as #2. When both are simultaneously ready the PIN now
+        -- surfaces Trueshot first; the anti-overlap BLACKLIST on Volley
+        -- (triggered by trueshot_just_cast) then forces at least one
+        -- intervening cast in typical play before Volley is shown again.
+        -- This trade is accepted because the prior behaviour (Trueshot
+        -- never surfaced at all) was strictly worse for the user reporting
+        -- issue #89, and the sequence still satisfies the guide's
+        -- "never back-to-back" Volley/Trueshot rule.
         {
             type = "PIN",
             spellID = SPELLS.Trueshot,
-            reason = "Post-RF Window",
+            reason = "Trueshot",
             condition = {
                 type = "and",
                 left  = { type = "ac_suggested", spellID = SPELLS.Trueshot },
-                right = {
-                    type = "and",
-                    left  = { type = "rapid_fire_recent", seconds = 3 },
-                    right = { type = "not", inner = { type = "volley_recent", seconds = 2 } },
-                },
+                right = { type = "in_combat" },
             },
         },
 

--- a/docs/MM_ROTATION_REFERENCE.md
+++ b/docs/MM_ROTATION_REFERENCE.md
@@ -58,7 +58,7 @@ Dark Ranger adds the clearest override value in two places:
 | Black Arrow immediately after Trueshot | `PIN` | `ba_ready AND trueshot_just_cast(2)` | Spend the free opener proc cleanly. |
 | Wailing Arrow inside Trueshot opener | `PIN` | `wa_available AND NOT ba_ready AND trueshot_active` | Preserve the intended `TS -> BA -> WA -> BA` flow. |
 | Black Arrow during Withering Fire | `PIN` | `ba_ready AND in_withering_fire` | Highest-value BA window in the Dark Ranger lane. |
-| Trueshot only after Rapid Fire and not after Volley | `PIN` | `ac_suggested(Trueshot) AND rapid_fire_recent(3) AND NOT volley_recent(2)` | Conservative post-RF gating without raw `IsSpellUsable()` dependence. |
+| Trueshot on the main cooldown | `PIN` | `ac_suggested(Trueshot) AND in_combat` | Surface Trueshot whenever Assisted Combat treats it as castable; the anti-overlap BLACKLIST rules still force a single interleaving GCD around Volley. Replaces a prior `rapid_fire_recent(3)` gate that treated the "Rapid Fire -> Trueshot -> Aimed Shot" guidance as a hard precondition and caused Trueshot to never surface for openers that did not begin with Rapid Fire (issue #89). |
 | Black Arrow outside Withering Fire | `PREFER` | `ba_ready AND NOT in_withering_fire` | Soft nudge only, not a full hard-override outside burst. |
 
 ### Legal signal basis
@@ -96,7 +96,7 @@ Its override layer is mainly about:
 | --- | --- | --- | --- |
 | Trueshot right after Volley blocked | `BLACKLIST_CONDITIONAL` | `volley_recent(2)` | Avoid overlap waste. |
 | Volley right after Trueshot blocked | `BLACKLIST_CONDITIONAL` | `trueshot_just_cast(2)` | Same anti-overlap in the other direction. |
-| Trueshot post-RF only | `PIN` | `ac_suggested(Trueshot) AND rapid_fire_recent(3) AND NOT volley_recent(2)` | Use Blizzard AC as the legal readiness gate, then tighten timing. |
+| Trueshot on the main cooldown | `PIN` | `ac_suggested(Trueshot) AND in_combat` | Sentinel surfaces Trueshot whenever Assisted Combat treats it as castable. Azortharion lists Volley as ST #1 for Sentinel; when both are simultaneously ready the PIN now surfaces Trueshot first and the anti-overlap BLACKLIST on Volley forces at least one intervening cast in typical play before Volley is shown again, which stays within the guide's anti-back-to-back rule. Replaces a prior `rapid_fire_recent(3)` gate that caused Trueshot to never surface for openers that did not start with Rapid Fire (issue #89). |
 | Moonlight Chakram outside Trueshot blocked | `BLACKLIST_CONDITIONAL` | `NOT trueshot_active` | Keep Chakram from surfacing in the wrong context. |
 | Moonlight Chakram as late Trueshot filler | `PREFER` | `ac_suggested(MoonlightChakram) AND trueshot_active AND NOT aimed_shot_ready` | Only elevate it when the safer filler window is present. |
 

--- a/tests/test_hunter_profiles.lua
+++ b/tests/test_hunter_profiles.lua
@@ -455,6 +455,180 @@ test("MM Sentinel: aimed_shot_ready reads non-secret charges", function()
 end)
 
 ------------------------------------------------------------------------
+-- Issue #89: Trueshot must surface even when Rapid Fire was not recent.
+--
+-- The prior PIN gated Trueshot on rapid_fire_recent(3), so a user who
+-- opened without Rapid Fire never saw Trueshot in the queue. The fix
+-- keeps the anti-overlap BLACKLIST_CONDITIONAL and the BLACKLIST on
+-- Volley-after-Trueshot intact, but removes the RF-recency requirement
+-- from the PIN condition. These tests lock down the post-fix shape for
+-- both MM profiles and guard against the regression re-appearing.
+------------------------------------------------------------------------
+
+-- Small helper: scan a profile's rules array and return the first PIN
+-- whose spellID matches. We use table inspection rather than a live
+-- Engine:ComputeQueue call because the structural rule shape is exactly
+-- what the regression guard is about.
+local function find_pin_rule(profile, spellID)
+    for _, rule in ipairs(profile.rules) do
+        if rule.type == "PIN" and rule.spellID == spellID then
+            return rule
+        end
+    end
+    return nil
+end
+
+local function eval_profile_or_engine(profile, cond)
+    local result = profile:EvalCondition(cond)
+    if result ~= nil then return result end
+    return TrueShot.Engine:EvalCondition(cond)
+end
+
+local function pin_condition_matches(profile, rule)
+    return eval_profile_or_engine(profile, rule.condition)
+end
+
+test("issue #89: MM DR Trueshot PIN does NOT depend on rapid_fire_recent", function()
+    local p = P("Hunter.MM.DarkRanger")
+    -- Simulate: AC suggests Trueshot, we are in combat, RF was never cast.
+    TrueShot.Engine._acSuggestedSpells = TrueShot.Engine._acSuggestedSpells or {}
+    local rule = find_pin_rule(p, 288613)
+    assert_true(rule ~= nil, "MM DR must expose a Trueshot PIN rule")
+    assert_true(rule.condition ~= nil, "Trueshot PIN must have a condition table")
+    -- Walk the condition tree and assert rapid_fire_recent is absent.
+    local function walk(c)
+        if not c then return false end
+        if c.type == "rapid_fire_recent" then return true end
+        if c.left and walk(c.left) then return true end
+        if c.right and walk(c.right) then return true end
+        if c.inner and walk(c.inner) then return true end
+        return false
+    end
+    assert_false(walk(rule.condition),
+        "MM DR Trueshot PIN must not gate on rapid_fire_recent (issue #89)")
+end)
+
+test("issue #89: MM Sentinel Trueshot PIN does NOT depend on rapid_fire_recent", function()
+    local p = P("Hunter.MM.Sentinel")
+    local rule = find_pin_rule(p, 288613)
+    assert_true(rule ~= nil, "MM Sentinel must expose a Trueshot PIN rule")
+    local function walk(c)
+        if not c then return false end
+        if c.type == "rapid_fire_recent" then return true end
+        if c.left and walk(c.left) then return true end
+        if c.right and walk(c.right) then return true end
+        if c.inner and walk(c.inner) then return true end
+        return false
+    end
+    assert_false(walk(rule.condition),
+        "MM Sentinel Trueshot PIN must not gate on rapid_fire_recent (issue #89)")
+end)
+
+-- Dynamic condition test: stub ac_suggested via the engine and confirm the
+-- Trueshot PIN now evaluates true without any Rapid Fire cast. The stub is
+-- restored after each test so subsequent tests see the real method.
+local _original_IsSpellSuggestedByAC = TrueShot.Engine.IsSpellSuggestedByAC
+
+local function force_ac_suggested(spellID, on)
+    -- Engine:IsSpellSuggestedByAC calls RefreshACSuggestions which wipes the
+    -- cache on every call. We monkey-patch it in tests to freeze our value.
+    TrueShot.Engine.IsSpellSuggestedByAC = function(_, id)
+        return id == spellID and on or false
+    end
+end
+
+local function restore_ac_suggested()
+    TrueShot.Engine.IsSpellSuggestedByAC = _original_IsSpellSuggestedByAC
+end
+
+test("issue #89: MM DR Trueshot PIN fires when AC suggests TS and no RF cast yet", function()
+    local p = P("Hunter.MM.DarkRanger")
+    force_ac_suggested(288613, true)
+    local rule = find_pin_rule(p, 288613)
+    local ok = pin_condition_matches(p, rule)
+    restore_ac_suggested()
+    assert_true(ok,
+        "Trueshot PIN must evaluate true when AC suggests TS and we are in combat, " ..
+        "regardless of Rapid Fire history")
+end)
+
+test("issue #89: MM Sentinel Trueshot PIN fires when AC suggests TS and no RF cast yet", function()
+    local p = P("Hunter.MM.Sentinel")
+    force_ac_suggested(288613, true)
+    local rule = find_pin_rule(p, 288613)
+    local ok = pin_condition_matches(p, rule)
+    restore_ac_suggested()
+    assert_true(ok,
+        "Sentinel Trueshot PIN must evaluate true when AC suggests TS and we are in combat")
+end)
+
+test("issue #89 regression guard: MM DR Volley anti-overlap BLACKLIST still exists", function()
+    -- If the fix accidentally drops the Volley->Trueshot anti-overlap the
+    -- "Never cast Volley and Trueshot back-to-back" rule from Azortharion is
+    -- violated. Confirm the BLACKLIST_CONDITIONAL on spell 288613 with a
+    -- volley_recent condition is still present.
+    local p = P("Hunter.MM.DarkRanger")
+    local found_anti_overlap = false
+    for _, rule in ipairs(p.rules) do
+        if rule.type == "BLACKLIST_CONDITIONAL"
+            and rule.spellID == 288613
+            and rule.condition and rule.condition.type == "volley_recent" then
+            found_anti_overlap = true
+        end
+    end
+    assert_true(found_anti_overlap,
+        "MM DR must keep BLACKLIST_CONDITIONAL Trueshot on volley_recent (anti-overlap)")
+end)
+
+test("issue #89 regression guard: MM Sentinel Volley anti-overlap BLACKLIST still exists", function()
+    local p = P("Hunter.MM.Sentinel")
+    local found_anti_overlap = false
+    for _, rule in ipairs(p.rules) do
+        if rule.type == "BLACKLIST_CONDITIONAL"
+            and rule.spellID == 288613
+            and rule.condition and rule.condition.type == "volley_recent" then
+            found_anti_overlap = true
+        end
+    end
+    assert_true(found_anti_overlap,
+        "MM Sentinel must keep BLACKLIST_CONDITIONAL Trueshot on volley_recent (anti-overlap)")
+end)
+
+test("issue #89 regression guard: MM DR Volley-after-Trueshot BLACKLIST still exists", function()
+    -- The reverse anti-overlap ensures that after we PIN Trueshot, Volley is
+    -- suppressed for 2 seconds so the rotation naturally interleaves one GCD
+    -- before Volley comes back. This is load-bearing for the Sentinel
+    -- Azortharion priority trade-off documented in the MM_Sentinel source
+    -- comment: with Trueshot pinned first, Volley must be blocked for one
+    -- GCD to reproduce "one cast between Volley and Trueshot".
+    local p = P("Hunter.MM.DarkRanger")
+    local found = false
+    for _, rule in ipairs(p.rules) do
+        if rule.type == "BLACKLIST_CONDITIONAL"
+            and rule.spellID == 260243 -- Volley
+            and rule.condition and rule.condition.type == "trueshot_just_cast" then
+            found = true
+        end
+    end
+    assert_true(found,
+        "MM DR must keep BLACKLIST_CONDITIONAL Volley on trueshot_just_cast")
+end)
+
+test("issue #89 regression guard: MM Sentinel Volley-after-Trueshot BLACKLIST still exists", function()
+    local p = P("Hunter.MM.Sentinel")
+    local found = false
+    for _, rule in ipairs(p.rules) do
+        if rule.type == "BLACKLIST_CONDITIONAL"
+            and rule.spellID == 260243
+            and rule.condition and rule.condition.type == "trueshot_just_cast" then
+            found = true
+        end
+    end
+    assert_true(found,
+        "MM Sentinel must keep BLACKLIST_CONDITIONAL Volley on trueshot_just_cast")
+end)
+
+------------------------------------------------------------------------
 -- SV Pack Leader
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #89. Both MM Hunter profiles (Dark Ranger and Sentinel) gated their only Trueshot PIN on `rapid_fire_recent(3)`, which treated the Azortharion "Rapid Fire -> Trueshot -> Aimed Shot" sequence as a hard precondition. Rapid Fire (~20s CD) and Trueshot (~2-3min CD) do not synchronise in practice, so any player whose opener did not start with Rapid Fire never saw Trueshot surface in the queue.

The PIN now fires on `ac_suggested(Trueshot) AND in_combat`. The existing anti-overlap rules keep enforcing the guide's "never back-to-back" Volley/Trueshot pattern:

- `BLACKLIST_CONDITIONAL Trueshot WHEN volley_recent(2)` suppresses Trueshot for 2s after Volley.
- `BLACKLIST_CONDITIONAL Volley WHEN trueshot_just_cast(2)` suppresses Volley for 2s after Trueshot, forcing at least one intervening cast in typical play.

## Sentinel trade-off

Azortharion lists Volley as single-target priority #1 for Sentinel and Trueshot as #2. When both are simultaneously ready the PIN now surfaces Trueshot first; the anti-overlap BLACKLIST on Volley then produces the "one cast between" interleave. This is accepted because the prior behaviour (Trueshot never surfaced at all) was strictly worse for the reporter, and the sequence still satisfies the guide's anti-back-to-back rule.

## Tests

Eight new regression guards in `tests/test_hunter_profiles.lua`:

- Four structural: walk the condition tree of each MM profile's Trueshot PIN and assert `rapid_fire_recent` is no longer reachable, plus assert both BLACKLIST_CONDITIONAL anti-overlap rules remain.
- Two dynamic: stub `Engine:IsSpellSuggestedByAC` to return true for Trueshot, confirm the PIN condition evaluates true without any Rapid Fire history, with the stub restored after each test.
- Two additional regression guards confirm the Volley-after-Trueshot BLACKLIST is preserved for both profiles.

Full suite: 41 Hunter + 21 CD ledger + 12 condition registry + 8 base64 = **82 passing, 0 failing**.

## Files changed

- `Profiles/MM_DarkRanger.lua` - Trueshot PIN simplified, `rapid_fire_recent` gate removed, inline comment explains the issue.
- `Profiles/MM_Sentinel.lua` - same shape, plus Sentinel Volley #1 trade-off note.
- `docs/MM_ROTATION_REFERENCE.md` - both Dark Ranger and Sentinel tables updated.
- `CHANGELOG.md` - new v0.25.1 entry on top.
- `tests/test_hunter_profiles.lua` - 8 new regression tests under an "Issue #89" section.

## Test plan

- [x] `luac -p` on every changed Lua file
- [x] `lua tests/test_hunter_profiles.lua` - 41 passed, 0 failed
- [x] `lua tests/test_cd_ledger.lua` - 21 passed, 0 failed
- [x] `lua tests/test_condition_registry.lua` - 12 passed, 0 failed
- [x] `lua tests/test_base64_decode.lua` - 8 passed, 0 failed
- [ ] Live in-game verification by the reporter that Trueshot now appears in the queue when it is ready.