### PR TITLE
Add local cooldown display fallback

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -114,6 +114,7 @@ eventFrame:RegisterEvent("PLAYER_TALENT_UPDATE")
 eventFrame:RegisterEvent("SPELLS_CHANGED")
 eventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 eventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+eventFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN")
 
 local function ShouldShowOverlay()
     if TrueShot.GetOpt("hidden") then return false end
@@ -183,6 +184,16 @@ eventFrame:SetScript("OnEvent", function(self, event, ...)
                 if Display.MarkDirty then Display:MarkDirty() end
             end
         end
+
+    elseif event == "SPELL_UPDATE_COOLDOWN" then
+        -- Best-effort reconcile: prunes ledger entries whose cooldowns are
+        -- demonstrably finished per a non-secret C_Spell read. Cast-event
+        -- entries with secret/unreadable responses are left intact so the
+        -- tier-3 visual swipe fallback keeps animating.
+        if TrueShot.CDLedger and TrueShot.CDLedger.ReconcileFromCooldownAPI then
+            TrueShot.CDLedger:ReconcileFromCooldownAPI()
+        end
+        if Display and Display.MarkDirty then Display:MarkDirty() end
 
     elseif event == "PLAYER_REGEN_DISABLED" then
         Engine.combatStartTime = GetTime()

--- a/Display.lua
+++ b/Display.lua
@@ -1146,6 +1146,24 @@ function Display:ApplyOptions()
 
 end
 
+-- Tier-3 visual fallback: render the swipe from the local CDLedger snapshot
+-- when DurationObject and direct readable C_Spell.GetSpellCooldown both fail.
+-- Issue #54: keeps the swipe accurate for spells whose cooldown values are
+-- secret-gated on this build. Visual only; engine truth still flows through
+-- CDLedger:IsOnCooldown via the regular condition seams.
+local function TrySetCooldownFromLedger(icon, spellID)
+    if not icon or not icon.cooldown or not spellID then return false end
+    local ledger = TrueShot.CDLedger
+    if not ledger or not ledger.GetDisplaySnapshot then return false end
+    local snap = ledger:GetDisplaySnapshot(spellID)
+    if not snap then return false end
+    if snap.duration < MIN_COOLDOWN_SWIPE_DURATION then return false end
+    if not icon.cooldown.SetCooldown then return false end
+    icon.cooldown:SetCooldown(snap.startTime, snap.duration, snap.modRate or 1)
+    icon.cooldown:Show()
+    return true
+end
+
 function Display:UpdateCooldown(icon, spellID)
     if not icon or not icon.cooldown then return end
     if not TrueShot.GetOpt("showCooldownSwipe") or not spellID then
@@ -1157,20 +1175,32 @@ function Display:UpdateCooldown(icon, spellID)
 
     -- Prefer slot-based cooldown state when available; this matches the visible
     -- action button more closely than spell-based secret cooldown data.
+    -- `apiAuthoritative` flips on only when a non-secret read produced a
+    -- definitive answer; if it stays false we treat the readable APIs as
+    -- "no answer" and the tier-3 ledger fallback may render the swipe.
     local shouldShow = false
     local actionBarResolved = false
+    local apiAuthoritative = false
     if actionSlot and C_ActionBar_GetActionCooldown then
         local ok, cooldown = pcall(C_ActionBar_GetActionCooldown, actionSlot)
         if ok and cooldown then
-            if cooldown.isActive ~= nil and not (issecretvalue and issecretvalue(cooldown.isActive)) then
-                shouldShow = cooldown.isActive == true
+            -- Cache isActive and gate it through issecretvalue BEFORE any
+            -- comparison: comparing a secret value to nil/true would taint the
+            -- boolean and leak through control flow. Only when the value is
+            -- known non-secret may we test it against nil and true.
+            local isActive = cooldown.isActive
+            local isActiveReadable = not (issecretvalue and issecretvalue(isActive))
+            if isActiveReadable and isActive ~= nil then
+                shouldShow = isActive == true
                 actionBarResolved = true
+                apiAuthoritative = true
             else
                 local startTime = cooldown.startTime or 0
                 local duration = cooldown.duration or 0
                 if not (issecretvalue and (issecretvalue(startTime) or issecretvalue(duration))) then
                     shouldShow = startTime > 0 and duration >= MIN_COOLDOWN_SWIPE_DURATION
                     actionBarResolved = true
+                    apiAuthoritative = true
                 end
             end
         end
@@ -1185,6 +1215,7 @@ function Display:UpdateCooldown(icon, spellID)
                 (issecretvalue(startTime) or issecretvalue(duration)))
             if valuesReadable then
                 shouldShow = startTime > 0 and duration >= MIN_COOLDOWN_SWIPE_DURATION
+                apiAuthoritative = true
             else
                 shouldShow = true  -- trust DurationObject to handle it
             end
@@ -1192,6 +1223,13 @@ function Display:UpdateCooldown(icon, spellID)
     end
 
     if not shouldShow then
+        -- Authoritative "not on CD" reads must be trusted - never overpaint
+        -- a ready spell with a stale local timer.
+        if apiAuthoritative then
+            ClearCooldown(icon)
+            return
+        end
+        if TrySetCooldownFromLedger(icon, spellID) then return end
         ClearCooldown(icon)
         return
     end
@@ -1215,35 +1253,27 @@ function Display:UpdateCooldown(icon, spellID)
         end
     end
 
-    -- Fallback: direct SetCooldown (pre-66562 or if DurationObject unavailable)
-    if not C_Spell_GetSpellCooldown then
-        ClearCooldown(icon)
-        return
+    -- Tier-2 fallback: direct SetCooldown with secret guards.
+    if C_Spell_GetSpellCooldown then
+        local ok, cooldown = pcall(C_Spell_GetSpellCooldown, spellID)
+        if ok and cooldown then
+            local startTime = cooldown.startTime or 0
+            local duration = cooldown.duration or 0
+            local readable = not (issecretvalue and
+                (issecretvalue(startTime) or issecretvalue(duration)))
+            if readable and startTime > 0 and duration >= MIN_COOLDOWN_SWIPE_DURATION
+               and icon.cooldown.SetCooldown then
+                icon.cooldown:SetCooldown(startTime, duration, cooldown.modRate or 1)
+                icon.cooldown:Show()
+                return
+            end
+        end
     end
 
-    local ok, cooldown = pcall(C_Spell_GetSpellCooldown, spellID)
-    if not ok or not cooldown then
-        ClearCooldown(icon)
-        return
-    end
+    -- Tier-3 fallback: local CDLedger snapshot (issue #54).
+    if TrySetCooldownFromLedger(icon, spellID) then return end
 
-    local startTime = cooldown.startTime or 0
-    local duration = cooldown.duration or 0
-
-    if issecretvalue and (issecretvalue(startTime) or issecretvalue(duration)) then
-        ClearCooldown(icon)
-        return
-    end
-
-    if startTime <= 0 or duration < MIN_COOLDOWN_SWIPE_DURATION then
-        ClearCooldown(icon)
-        return
-    end
-
-    if icon.cooldown.SetCooldown then
-        icon.cooldown:SetCooldown(startTime, duration, cooldown.modRate or 1)
-    end
-    icon.cooldown:Show()
+    ClearCooldown(icon)
 end
 
 function Display:UpdateChargeCooldown(icon, spellID)

--- a/State/CDLedger.lua
+++ b/State/CDLedger.lua
@@ -234,6 +234,72 @@ function CDLedger:OnCombatEnd()
     -- no-op by design
 end
 
+------------------------------------------------------------------------
+-- Display snapshot (tier-3 cooldown rendering fallback)
+--
+-- Display.lua's preferred path is DurationObject (action slot, then spell),
+-- followed by direct readable C_Spell.GetSpellCooldown values. When BOTH are
+-- unavailable (DurationObject helpers missing on this build) and the direct
+-- read is secret-gated, the swipe would otherwise blank.
+--
+-- This snapshot is a visual-only last-resort: shape matches Cooldown:SetCooldown
+-- (startTime, duration, modRate). It is NOT a strict-mode rotation truth source
+-- - the engine still consults IsOnCooldown / SecondsUntilReady through their
+-- existing seams, which carry the same caveats.
+--
+-- Returns nil for:
+--   * secret spellIDs
+--   * spells outside the tracked spec
+--   * timers that have already expired
+------------------------------------------------------------------------
+
+function CDLedger:GetDisplaySnapshot(spellID)
+    if not spellID or IsSecret(spellID) then return nil end
+    if not self.spec[spellID] then return nil end
+    local st = self.state[spellID]
+    if not st then return nil end
+    local now = GetTime()
+    if st.expected_ready <= now then return nil end
+    local duration = st.expected_ready - st.cast_time
+    if duration <= 0 then return nil end
+    return {
+        startTime = st.cast_time,
+        duration = duration,
+        modRate = 1,
+    }
+end
+
+------------------------------------------------------------------------
+-- Reconcile against C_Spell.GetSpellCooldown
+--
+-- Hook for SPELL_UPDATE_COOLDOWN. Best-effort, secret-guarded: only prunes a
+-- ledger entry when the API returns NON-SECRET values that authoritatively
+-- mean "not on cooldown" (zero startTime or zero duration). Secret/unreadable
+-- responses leave the local timer untouched, so the tier-3 display fallback
+-- stays accurate when the player just cast a gated spell.
+--
+-- Never seeds new entries: that is ReseedFromCooldownAPI's job, and we do not
+-- want a SPELL_UPDATE_COOLDOWN flood to clobber the cast-event ledger.
+------------------------------------------------------------------------
+
+function CDLedger:ReconcileFromCooldownAPI()
+    if not C_Spell or not C_Spell.GetSpellCooldown then return end
+    for spellID in pairs(self.state) do
+        local ok, cooldown = pcall(C_Spell.GetSpellCooldown, spellID)
+        if ok and type(cooldown) == "table" then
+            local startTime = cooldown.startTime
+            local duration = cooldown.duration
+            local readable = type(startTime) == "number"
+                and type(duration) == "number"
+                and not IsSecret(startTime)
+                and not IsSecret(duration)
+            if readable and (startTime <= 0 or duration <= 0) then
+                self.state[spellID] = nil
+            end
+        end
+    end
+end
+
 function CDLedger:ReseedFromCooldownAPI()
     local now = GetTime()
     self.state = {}

--- a/docs/API_CONSTRAINTS.md
+++ b/docs/API_CONSTRAINTS.md
@@ -144,6 +144,7 @@ These are acceptable only when their output is non-authoritative, display-only, 
 - "The target is casting, so interrupt can be surfaced."
 - "Nameplate count is at least N, so prefer an AoE branch."
 - "Spell X was cast, `GetSpellBaseCooldown` returns 30000ms (non-secret), and we observed cast success, so Spell X is on cooldown until `GetTime() + 30`." This is the `State/CDLedger` pattern. Live `GetSpellBaseCooldown` values are preferred (they reflect talent CDR), with hardcoded `spec.base_ms` as a fallback when the API returns 0, nil, or secret. Haste scaling is applied through `UnitSpellHaste("player")` only for spells explicitly flagged `haste_scaled`, and degrades cleanly to "no scaling" when the read is secret.
+- "DurationObject and direct `C_Spell.GetSpellCooldown` reads are both unavailable for the action-button swipe, so render the swipe from the `CDLedger` cast-event snapshot as a tier-3 visual fallback." Used purely for the cooldown swipe animation when the preferred readers cannot render. This does not promote the local timer into rotation truth: strict-mode `cd_ready` / `cd_remaining` consumers still go through the same event-tracked seam with the heuristic caveats above. `SPELL_UPDATE_COOLDOWN` triggers `CDLedger:ReconcileFromCooldownAPI`, which only prunes entries when a non-secret API read authoritatively reports "not on cooldown" - secret responses leave the local timer (and its visual fallback) intact.
 
 Strict-mode baseline:
 

--- a/tests/test_cd_ledger.lua
+++ b/tests/test_cd_ledger.lua
@@ -409,6 +409,122 @@ test("SecondsSinceCast returns nil before any cast, and elapsed time after", fun
 end)
 
 ------------------------------------------------------------------------
+-- Display snapshot (tier-3 cooldown rendering fallback)
+--
+-- Display.lua prefers DurationObject and direct readable C_Spell.GetSpellCooldown
+-- paths. When both are unavailable or secret-gated, it asks the ledger for a
+-- visual-only snapshot derived from the cast-event timer. The snapshot must:
+--   - mirror the SetCooldown(startTime, duration, modRate) shape
+--   - only describe spells we already track (no inventing for unknown IDs)
+--   - only describe currently-active timers with positive remaining time
+--   - propagate shared cooldowns the same way IsOnCooldown does
+------------------------------------------------------------------------
+
+test("GetDisplaySnapshot returns nil for unknown spell", function()
+    assert_true(CDLedger:GetDisplaySnapshot(123456789) == nil,
+        "Snapshot must not invent state for spells outside the spec")
+end)
+
+test("GetDisplaySnapshot returns nil when spell has never been cast", function()
+    assert_true(CDLedger:GetDisplaySnapshot(19574) == nil,
+        "Tracked spell with no cast observed yet has no display snapshot")
+end)
+
+test("GetDisplaySnapshot returns startTime/duration/modRate after cast", function()
+    set_time(1000)
+    CDLedger:OnSpellCastSucceeded(19574)
+    local snap = CDLedger:GetDisplaySnapshot(19574)
+    assert_true(snap ~= nil, "Active CD must produce a snapshot")
+    assert_near(snap.startTime, 1000, 0.01, "startTime should be the cast time")
+    assert_near(snap.duration, 30, 0.01, "duration should be the resolved CD seconds")
+    assert_near(snap.modRate, 1, 0.0,
+        "modRate must be 1 (wall-clock countdown, no haste-rate fakery)")
+end)
+
+test("GetDisplaySnapshot returns nil after cooldown expires", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    advance_time(30.5)
+    assert_true(CDLedger:GetDisplaySnapshot(19574) == nil,
+        "Expired timers must not produce a swipe snapshot")
+end)
+
+test("GetDisplaySnapshot survives time advances mid-cooldown", function()
+    set_time(2000)
+    CDLedger:OnSpellCastSucceeded(288613) -- Trueshot, 120s
+    advance_time(45)
+    local snap = CDLedger:GetDisplaySnapshot(288613)
+    assert_true(snap ~= nil)
+    assert_near(snap.startTime, 2000, 0.01,
+        "startTime must remain the original cast time, not the query time")
+    assert_near(snap.duration, 120, 0.01,
+        "duration must remain the full CD length so SetCooldown can compute remaining itself")
+end)
+
+test("GetDisplaySnapshot honors shared cooldowns (Berserk/Incarnation)", function()
+    CDLedger:OnSpellCastSucceeded(102543) -- Incarnation
+    local snapBerserk = CDLedger:GetDisplaySnapshot(106951)
+    assert_true(snapBerserk ~= nil,
+        "Shared cooldown sibling must report the same active swipe")
+    assert_near(snapBerserk.duration, 180, 0.01)
+end)
+
+test("GetDisplaySnapshot ignores secret spellID payloads", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    local prev = _G.issecretvalue
+    _G.issecretvalue = function(_) return true end
+    local snap = CDLedger:GetDisplaySnapshot(19574)
+    _G.issecretvalue = prev
+    assert_true(snap == nil,
+        "Secret spellID must short-circuit before touching ledger state")
+end)
+
+------------------------------------------------------------------------
+-- SPELL_UPDATE_COOLDOWN reconcile
+--
+-- The ledger optionally reconciles its state against C_Spell.GetSpellCooldown
+-- when SPELL_UPDATE_COOLDOWN fires. It must:
+--   - prune entries where the API authoritatively reports "not on CD"
+--   - leave entries alone when the API value is secret or unreadable
+--   - never invent state for spells that are not in the spec
+------------------------------------------------------------------------
+
+test("ReconcileFromCooldownAPI prunes spells the API reports as not-on-CD", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    assert_true(CDLedger:IsOnCooldown(19574))
+    -- API authoritatively says "not on CD" for BW (CDR proc, talent reset, etc.)
+    _cooldown_snapshot[19574] = { startTime = 0, duration = 0, isEnabled = true, modRate = 1 }
+    CDLedger:ReconcileFromCooldownAPI()
+    assert_false(CDLedger:IsOnCooldown(19574),
+        "Authoritative non-secret zero from API must clear stale ledger entry")
+end)
+
+test("ReconcileFromCooldownAPI keeps state when API returns secret values", function()
+    CDLedger:OnSpellCastSucceeded(19574)
+    _cooldown_snapshot[19574] = {
+        startTime = "SECRET_START",
+        duration = "SECRET_DURATION",
+        isEnabled = true,
+        modRate = 1,
+    }
+    local prev = _G.issecretvalue
+    _G.issecretvalue = function(v)
+        return v == "SECRET_START" or v == "SECRET_DURATION"
+    end
+    CDLedger:ReconcileFromCooldownAPI()
+    _G.issecretvalue = prev
+    assert_true(CDLedger:IsOnCooldown(19574),
+        "Secret API reads must NOT clobber the locally tracked timer")
+end)
+
+test("ReconcileFromCooldownAPI does not invent state for untracked spells", function()
+    -- API claims an unrelated spell is on CD, but we don't track it.
+    _cooldown_snapshot[888888] = { startTime = 1000, duration = 60, isEnabled = true, modRate = 1 }
+    CDLedger:ReconcileFromCooldownAPI()
+    assert_false(CDLedger:IsOnCooldown(888888),
+        "Reconcile must not seed entries outside the spec")
+end)
+
+------------------------------------------------------------------------
 -- Secret spellID protection
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- adds a visual-only local cooldown fallback when the cooldown API cannot expose readable values
- keeps authoritative cooldown reads ahead of local fallback data
- clears stale local visuals when the API reports a readable ready state
- documents the fallback behavior and API boundary

## Tests
- `scripts/run_tests.sh`
- `git diff --check`

Closes #54
