### PR TITLE
Fix Frost Glacial Spike and custom spell selectors

### DIFF
--- a/Profiles/Frost_Frostfire.lua
+++ b/Profiles/Frost_Frostfire.lua
@@ -5,6 +5,22 @@ local Engine = TrueShot.Engine
 
 local FROZEN_ORB_DURATION = 10
 
+local SPELLS = {
+    GlacialSpike  = 199786,
+    Flurry        = 44614,
+    IceLance      = 30455,
+    Blizzard      = 190356,
+    FrozenOrb     = 84714,
+    Frostbolt     = 116,
+    IceNova       = 157997,
+    RayOfFrost    = 205021,
+    CometStorm    = 153595,
+    IcyVeins      = 12472,
+    Polymorph     = 118,
+    Spellsteal    = 30449,
+    ArcaneInt     = 1459,
+}
+
 local Profile = {
     id = "Mage.Frost.Frostfire",
     displayName = "Frost Frostfire",
@@ -18,23 +34,45 @@ local Profile = {
         lastCastWasFlurry = false,
     },
 
+    rotationalSpells = {
+        [SPELLS.GlacialSpike] = true,
+        [SPELLS.Flurry]       = true,
+        [SPELLS.IceLance]     = true,
+        [SPELLS.Blizzard]     = true,
+        [SPELLS.FrozenOrb]    = true,
+        [SPELLS.Frostbolt]    = true,
+        [SPELLS.IceNova]      = true,
+        [SPELLS.RayOfFrost]   = true,
+        [SPELLS.CometStorm]   = true,
+        [SPELLS.IcyVeins]     = true,
+    },
+
     rules = {
-        { type = "BLACKLIST", spellID = 118 },     -- Polymorph
-        { type = "BLACKLIST", spellID = 30449 },   -- Spellsteal
-        { type = "BLACKLIST", spellID = 1459 },    -- Arcane Intellect
+        { type = "BLACKLIST", spellID = SPELLS.Polymorph },
+        { type = "BLACKLIST", spellID = SPELLS.Spellsteal },
+        { type = "BLACKLIST", spellID = SPELLS.ArcaneInt },
+
+        -- Glacial Spike: when the client exposes the proc glow, prefer it
+        -- without trying to read hidden Icicle stack state.
+        {
+            type = "PREFER",
+            spellID = SPELLS.GlacialSpike,
+            reason = "Glacial Spike",
+            condition = { type = "spell_glowing", spellID = SPELLS.GlacialSpike },
+        },
 
         -- Brain Freeze: PREFER Flurry when proc is active (glow detection)
         {
             type = "PREFER",
-            spellID = 44614, -- Flurry
+            spellID = SPELLS.Flurry,
             reason = "Brain Freeze",
-            condition = { type = "spell_glowing", spellID = 44614 },
+            condition = { type = "spell_glowing", spellID = SPELLS.Flurry },
         },
 
         -- Shatter combo: Ice Lance after Flurry (WCL: 66% natural, boost remaining 34%)
         {
             type = "PREFER",
-            spellID = 30455, -- Ice Lance
+            spellID = SPELLS.IceLance,
             reason = "Shatter",
             condition = { type = "last_cast_was_flurry" },
         },
@@ -42,7 +80,7 @@ local Profile = {
         -- Blizzard: AoE preference when 3+ targets
         {
             type = "PREFER",
-            spellID = 190356, -- Blizzard
+            spellID = SPELLS.Blizzard,
             reason = "AoE 3+",
             condition = { type = "target_count", op = ">=", value = 3 },
         },
@@ -57,11 +95,11 @@ end
 function Profile:OnSpellCast(spellID)
     local s = self.state
 
-    if spellID == 84714 then -- Frozen Orb
+    if spellID == SPELLS.FrozenOrb then
         s.frozenOrbActiveUntil = GetTime() + FROZEN_ORB_DURATION
     end
 
-    s.lastCastWasFlurry = (spellID == 44614) -- Flurry
+    s.lastCastWasFlurry = (spellID == SPELLS.Flurry)
 end
 
 function Profile:OnCombatEnd()

--- a/Profiles/Frost_Spellslinger.lua
+++ b/Profiles/Frost_Spellslinger.lua
@@ -3,6 +3,22 @@
 
 local Engine = TrueShot.Engine
 
+local SPELLS = {
+    GlacialSpike  = 199786,
+    Flurry        = 44614,
+    IceLance      = 30455,
+    FrozenOrb     = 84714,
+    Frostbolt     = 116,
+    Blizzard      = 190356,
+    IceNova       = 157997,
+    RayOfFrost    = 205021,
+    CometStorm    = 153595,
+    IcyVeins      = 12472,
+    Polymorph     = 118,
+    Spellsteal    = 30449,
+    ArcaneInt     = 1459,
+}
+
 local Profile = {
     id = "Mage.Frost.Spellslinger",
     displayName = "Frost Spellslinger",
@@ -23,17 +39,38 @@ local Profile = {
 
     state = {},
 
+    rotationalSpells = {
+        [SPELLS.GlacialSpike] = true,
+        [SPELLS.Flurry]       = true,
+        [SPELLS.IceLance]     = true,
+        [SPELLS.FrozenOrb]    = true,
+        [SPELLS.Frostbolt]    = true,
+        [SPELLS.Blizzard]     = true,
+        [SPELLS.IceNova]      = true,
+        [SPELLS.RayOfFrost]   = true,
+        [SPELLS.CometStorm]   = true,
+        [SPELLS.IcyVeins]     = true,
+    },
+
     rules = {
-        { type = "BLACKLIST", spellID = 118 },     -- Polymorph
-        { type = "BLACKLIST", spellID = 30449 },   -- Spellsteal
-        { type = "BLACKLIST", spellID = 1459 },    -- Arcane Intellect
+        { type = "BLACKLIST", spellID = SPELLS.Polymorph },
+        { type = "BLACKLIST", spellID = SPELLS.Spellsteal },
+        { type = "BLACKLIST", spellID = SPELLS.ArcaneInt },
+
+        -- Glacial Spike: prefer the proc when the client exposes the glow.
+        {
+            type = "PREFER",
+            spellID = SPELLS.GlacialSpike,
+            reason = "Glacial Spike",
+            condition = { type = "spell_glowing", spellID = SPELLS.GlacialSpike },
+        },
 
         -- Brain Freeze: PREFER Flurry when proc is active (glow detection)
         {
             type = "PREFER",
-            spellID = 44614, -- Flurry
+            spellID = SPELLS.Flurry,
             reason = "Brain Freeze",
-            condition = { type = "spell_glowing", spellID = 44614 },
+            condition = { type = "spell_glowing", spellID = SPELLS.Flurry },
         },
     },
 }

--- a/RuleBuilder.lua
+++ b/RuleBuilder.lua
@@ -128,9 +128,25 @@ local function RemoveConditionType(condition, typeId)
 end
 
 local function GetSpellDisplay(spellID)
-    if not spellID then return nil, "Unknown" end
-    local name = C_Spell and C_Spell.GetSpellName and C_Spell.GetSpellName(spellID) or "Spell " .. spellID
-    local icon = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(spellID) or 134400
+    if not spellID then return nil, "Select spell" end
+
+    local name
+    if C_Spell and C_Spell.GetSpellName then
+        local ok, result = pcall(C_Spell.GetSpellName, spellID)
+        if ok and result and not (issecretvalue and issecretvalue(result)) then
+            name = result
+        end
+    end
+    name = name or ("Spell " .. tostring(spellID))
+
+    local icon = 134400
+    if C_Spell and C_Spell.GetSpellTexture then
+        local ok, result = pcall(C_Spell.GetSpellTexture, spellID)
+        if ok and result and not (issecretvalue and issecretvalue(result)) then
+            icon = result
+        end
+    end
+
     return icon, name
 end
 
@@ -1229,7 +1245,17 @@ local function CreateParamInputs(parent, condition, schema, anchorTo, onChange)
             UIDropDownMenu_SetWidth(dd, 130)
 
             local spellList = GetRotationalSpellList()
+            local manualEdit
             UIDropDownMenu_Initialize(dd, function()
+                if #spellList == 0 then
+                    local info = UIDropDownMenu_CreateInfo()
+                    info.text = "No profile spells"
+                    info.notClickable = true
+                    info.disabled = true
+                    UIDropDownMenu_AddButton(info)
+                    return
+                end
+
                 for _, sid in ipairs(spellList) do
                     local sIcon, sName = GetSpellDisplay(sid)
                     local info = UIDropDownMenu_CreateInfo()
@@ -1239,6 +1265,7 @@ local function CreateParamInputs(parent, condition, schema, anchorTo, onChange)
                     info.func = function()
                         condition[param.field] = sid
                         UIDropDownMenu_SetText(dd, sName)
+                        if manualEdit then manualEdit:SetText(tostring(sid)) end
                         if onChange then onChange() end
                     end
                     UIDropDownMenu_AddButton(info)
@@ -1247,7 +1274,39 @@ local function CreateParamInputs(parent, condition, schema, anchorTo, onChange)
 
             local _, curName = GetSpellDisplay(condition[param.field])
             UIDropDownMenu_SetText(dd, curName)
-            lastAnchor = dd
+
+            local manualRow = CreateFrame("Frame", nil, parent)
+            TrackFrame(manualRow)
+            manualRow:SetSize(220, 22)
+            manualRow:SetPoint("TOPLEFT", dd, "BOTTOMLEFT", 16, -4)
+
+            local manualLabel = manualRow:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+            manualLabel:SetPoint("LEFT", manualRow, "LEFT", 0, 0)
+            manualLabel:SetText((param.label or "Spell") .. " ID:")
+
+            manualEdit = CreateFrame("EditBox", nil, manualRow, "InputBoxTemplate")
+            manualEdit:SetSize(80, 20)
+            manualEdit:SetPoint("LEFT", manualLabel, "RIGHT", 6, 0)
+            manualEdit:SetAutoFocus(false)
+            manualEdit:SetNumeric(true)
+            manualEdit:SetText(condition[param.field] and tostring(condition[param.field]) or "")
+
+            local function ApplyManualSpell()
+                local val = tonumber(manualEdit:GetText())
+                if val and val > 0 and condition[param.field] ~= val then
+                    condition[param.field] = val
+                    local _, name = GetSpellDisplay(val)
+                    UIDropDownMenu_SetText(dd, name)
+                    if onChange then onChange() end
+                end
+            end
+            manualEdit:SetScript("OnEnterPressed", function(self)
+                ApplyManualSpell()
+                self:ClearFocus()
+            end)
+            manualEdit:SetScript("OnEditFocusLost", ApplyManualSpell)
+
+            lastAnchor = manualRow
 
         elseif param.fieldType == "operator" then
             local ddName = NextDropdownName("TrueShotRBOp_")
@@ -1693,7 +1752,17 @@ function RuleBuilder:ShowRuleEditor(index)
     UIDropDownMenu_SetWidth(spellDd, 180)
 
     local spellList = GetRotationalSpellList()
+    local manualEdit
     UIDropDownMenu_Initialize(spellDd, function()
+        if #spellList == 0 then
+            local info = UIDropDownMenu_CreateInfo()
+            info.text = "No profile spells"
+            info.notClickable = true
+            info.disabled = true
+            UIDropDownMenu_AddButton(info)
+            return
+        end
+
         for _, sid in ipairs(spellList) do
             local sIcon, sName = GetSpellDisplay(sid)
             local info = UIDropDownMenu_CreateInfo()
@@ -1703,6 +1772,7 @@ function RuleBuilder:ShowRuleEditor(index)
             info.func = function()
                 rule.spellID = sid
                 UIDropDownMenu_SetText(spellDd, sName)
+                if manualEdit then manualEdit:SetText(tostring(sid)) end
                 RuleBuilder:RefreshRuleList()
             end
             UIDropDownMenu_AddButton(info)
@@ -1722,7 +1792,7 @@ function RuleBuilder:ShowRuleEditor(index)
     manualLabel:SetPoint("LEFT", manualRow, "LEFT", 0, 0)
     manualLabel:SetText("or SpellID:")
 
-    local manualEdit = CreateFrame("EditBox", nil, manualRow, "InputBoxTemplate")
+    manualEdit = CreateFrame("EditBox", nil, manualRow, "InputBoxTemplate")
     manualEdit:SetSize(80, 20)
     manualEdit:SetPoint("LEFT", manualLabel, "RIGHT", 6, 0)
     manualEdit:SetAutoFocus(false)
@@ -1734,7 +1804,7 @@ function RuleBuilder:ShowRuleEditor(index)
 
     local function ApplyManualSpell()
         local val = tonumber(manualEdit:GetText())
-        if val and val > 0 then
+        if val and val > 0 and rule.spellID ~= val then
             rule.spellID = val
             local _, name = GetSpellDisplay(val)
             UIDropDownMenu_SetText(spellDd, name)

--- a/tests/test_engine_hero_talent.lua
+++ b/tests/test_engine_hero_talent.lua
@@ -41,13 +41,17 @@ _G.C_ClassTalents.GetActiveHeroTalentSpec = function()
 end
 
 _G.C_NamePlate = _G.C_NamePlate or { GetNamePlates = function() return {} end }
+local _ac_available = false
+local _ac_next_spell = nil
+local _ac_rotation_spells = {}
 _G.C_AssistedCombat = _G.C_AssistedCombat or {
-    IsAvailable = function() return false end,
-    GetNextCastSpell = function() return nil end,
-    GetRotationSpells = function() return {} end,
+    IsAvailable = function() return _ac_available end,
+    GetNextCastSpell = function() return _ac_next_spell end,
+    GetRotationSpells = function() return _ac_rotation_spells end,
 }
+local _overlayed_spells = {}
 _G.C_SpellActivationOverlay = _G.C_SpellActivationOverlay or {
-    IsSpellOverlayed = function() return false end,
+    IsSpellOverlayed = function(spellID) return _overlayed_spells[spellID] == true end,
 }
 _G.C_Spell = _G.C_Spell or {}
 _G.C_Spell.IsSpellUsable = function(_) return true end
@@ -146,6 +150,10 @@ local function test(name, fn)
     _active_hero_subtree = nil
     _player_spells = {}
     Engine.activeProfile = nil
+    _ac_available = false
+    _ac_next_spell = nil
+    _ac_rotation_spells = {}
+    _overlayed_spells = {}
     local ok, err = pcall(fn)
     if ok then
         passed = passed + 1
@@ -167,6 +175,27 @@ local function assert_profile(id)
     local active = Engine.activeProfile
     assert_true(active ~= nil, "Engine should have activated a profile")
     assert_eq(active.id, id, "Engine activated the wrong profile")
+end
+
+
+local function get_profile(specID, profileID)
+    local candidates = TrueShot.Profiles[specID]
+    if not candidates then return nil end
+    for _, p in ipairs(candidates) do
+        if p.id == profileID then return p end
+    end
+    return nil
+end
+
+local function has_rule(profile, ruleType, spellID, conditionType)
+    for _, rule in ipairs(profile.rules or {}) do
+        if rule.type == ruleType and rule.spellID == spellID then
+            if not conditionType or (rule.condition and rule.condition.type == conditionType) then
+                return true
+            end
+        end
+    end
+    return false
 end
 
 local function assert_profile_metadata(specID, profileID, expected)
@@ -196,6 +225,38 @@ test("All supported hero-path profiles declare subtree IDs and expected fallback
             assert_profile_metadata(specID, profileID, expected)
         end
     end
+end)
+
+
+test("Frost profiles expose Glacial Spike for custom spell selectors", function()
+    local glacialSpike = 199786
+    for _, profileID in ipairs({ "Mage.Frost.Frostfire", "Mage.Frost.Spellslinger" }) do
+        local profile = get_profile(64, profileID)
+        assert_true(profile ~= nil, "Frost profile should be registered: " .. profileID)
+        assert_true(profile.rotationalSpells and profile.rotationalSpells[glacialSpike] == true,
+            profileID .. " should include Glacial Spike in rotationalSpells")
+        assert_true(has_rule(profile, "PREFER", glacialSpike, "spell_glowing"),
+            profileID .. " should prefer Glacial Spike when its proc glow is exposed")
+    end
+end)
+
+test("Frost Glacial Spike glow rule can surface ahead of AC filler", function()
+    local glacialSpike = 199786
+    local frostbolt = 116
+    local profile = get_profile(64, "Mage.Frost.Frostfire")
+    assert_true(profile ~= nil, "Frost Frostfire profile should be registered")
+
+    Engine.activeProfile = profile
+    Engine:RebuildBlacklist()
+    _player_spells[frostbolt] = true
+    _player_spells[glacialSpike] = true
+    _ac_available = true
+    _ac_next_spell = frostbolt
+    _ac_rotation_spells = { frostbolt, glacialSpike }
+    _overlayed_spells[glacialSpike] = true
+
+    local queue = Engine:ComputeQueue(3)
+    assert_eq(queue[1], glacialSpike, "glowing Glacial Spike should be preferred over AC filler")
 end)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- adds Frost Mage rotational spell catalogs so Custom Profile spell selectors include Glacial Spike
- prefers Glacial Spike when the client exposes its proc glow, without reading hidden stack state
- improves Rule Builder spell labels and manual spell ID fallback behavior
- adds regression coverage for the Frost selector data and Glacial Spike queue preference

## Tests
- `scripts/run_tests.sh`
- `git diff --check`

Closes #94
