### PR TITLE
Add optional cooldown numbers

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -17,6 +17,7 @@ local DEFAULTS = {
     locked = false,
     enableDiagnostics = false,
     showCooldownSwipe = true,
+    showCooldownText = false,
     showCastFeedback = true,
     showWhyOverlay = false,
     showPhaseIndicator = false,

--- a/Display.lua
+++ b/Display.lua
@@ -101,6 +101,12 @@ if MasqueGroup then
     end)
 end
 
+local function ClearCooldownText(icon)
+    if not icon or not icon.cooldownText then return end
+    icon.cooldownText:SetText("")
+    icon.cooldownText:Hide()
+end
+
 local function ClearCooldown(icon)
     if not icon or not icon.cooldown then return end
     if icon.cooldown.Clear then
@@ -109,6 +115,7 @@ local function ClearCooldown(icon)
         icon.cooldown:SetCooldown(0, 0)
     end
     icon.cooldown:Hide()
+    ClearCooldownText(icon)
 end
 
 local function ResetStoredQueue(state)
@@ -535,6 +542,15 @@ local function CreateIcon(index)
     frame.chargeCount:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -2, 2)
     frame.chargeCount:SetJustifyH("RIGHT")
     frame.chargeCount:Hide()
+
+    -- Remaining cooldown text overlay. Parented to the cooldown frame so it
+    -- naturally sits above the swipe; visibility is gated explicitly by
+    -- UpdateCooldownText (option toggle, swipe option, secret guards).
+    frame.cooldownText = frame.cooldown:CreateFontString(nil, "OVERLAY", "NumberFontNormalLarge")
+    frame.cooldownText:SetPoint("CENTER", frame.cooldown, "CENTER", 0, 0)
+    frame.cooldownText:SetJustifyH("CENTER")
+    frame.cooldownText:SetJustifyV("MIDDLE")
+    frame.cooldownText:Hide()
 
     frame.keybind = frame:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmallGray")
     frame.keybind:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -2, -2)
@@ -1276,6 +1292,90 @@ function Display:UpdateCooldown(icon, spellID)
     ClearCooldown(icon)
 end
 
+-- Read remaining cooldown for the text overlay using the same source priority
+-- as UpdateCooldown: action bar (when authoritative), then direct C_Spell, then
+-- the local CDLedger snapshot. Returns nil if the spell is ready, the values
+-- are secret, or the cooldown is shorter than MIN_COOLDOWN_SWIPE_DURATION.
+local function ReadRemainingCooldownSeconds(spellID)
+    if not spellID then return nil end
+    local now = GetTime()
+    local actionSlot = GetActionSlotForSpell(spellID)
+
+    if actionSlot and C_ActionBar_GetActionCooldown then
+        local ok, cooldown = pcall(C_ActionBar_GetActionCooldown, actionSlot)
+        if ok and cooldown then
+            local startTime = cooldown.startTime
+            local duration = cooldown.duration
+            local readable = type(startTime) == "number" and type(duration) == "number"
+                and not (issecretvalue and (issecretvalue(startTime) or issecretvalue(duration)))
+            if readable then
+                if startTime > 0 and duration >= MIN_COOLDOWN_SWIPE_DURATION then
+                    local remaining = (startTime + duration) - now
+                    if remaining > 0 then return remaining end
+                end
+                return nil
+            end
+        end
+    end
+
+    if C_Spell_GetSpellCooldown then
+        local ok, cooldown = pcall(C_Spell_GetSpellCooldown, spellID)
+        if ok and cooldown then
+            local startTime = cooldown.startTime
+            local duration = cooldown.duration
+            local readable = type(startTime) == "number" and type(duration) == "number"
+                and not (issecretvalue and (issecretvalue(startTime) or issecretvalue(duration)))
+            if readable then
+                if startTime > 0 and duration >= MIN_COOLDOWN_SWIPE_DURATION then
+                    local remaining = (startTime + duration) - now
+                    if remaining > 0 then return remaining end
+                end
+                return nil
+            end
+        end
+    end
+
+    local ledger = TrueShot.CDLedger
+    if ledger and ledger.GetDisplaySnapshot then
+        local snap = ledger:GetDisplaySnapshot(spellID)
+        if snap and snap.duration >= MIN_COOLDOWN_SWIPE_DURATION then
+            local remaining = (snap.startTime + snap.duration) - now
+            if remaining > 0 then return remaining end
+        end
+    end
+
+    return nil
+end
+
+local function FormatCooldownRemaining(remaining)
+    if remaining >= 60 then
+        return string.format("%dm", math.ceil(remaining / 60))
+    end
+    if remaining >= 10 then
+        return string.format("%d", math.ceil(remaining))
+    end
+    return string.format("%.1f", remaining)
+end
+
+function Display:UpdateCooldownText(icon, spellID)
+    if not icon or not icon.cooldownText then return end
+    if not TrueShot.GetOpt("showCooldownText")
+        or not TrueShot.GetOpt("showCooldownSwipe")
+        or not spellID then
+        ClearCooldownText(icon)
+        return
+    end
+
+    local remaining = ReadRemainingCooldownSeconds(spellID)
+    if not remaining then
+        ClearCooldownText(icon)
+        return
+    end
+
+    icon.cooldownText:SetText(FormatCooldownRemaining(remaining))
+    icon.cooldownText:Show()
+end
+
 function Display:UpdateChargeCooldown(icon, spellID)
     if not icon or not icon.chargeCooldown then return end
     if not TrueShot.GetOpt("showCooldownSwipe") or not spellID then
@@ -1429,6 +1529,7 @@ function Display:UpdateQueue(queue)
 
                 icon.spellID = spellID
                 self:UpdateCooldown(icon, spellID)
+                self:UpdateCooldownText(icon, spellID)
                 self:UpdateChargeCooldown(icon, spellID)
                 self:UpdateCastFeedback(icon, now)
                 icon:Show()

--- a/SettingsPanel.lua
+++ b/SettingsPanel.lua
@@ -407,10 +407,16 @@ local function CreateFeaturesPanel()
         castDesc, "showCooldownSwipe"
     )
 
+    local cooldownTextCheck, cooldownTextDesc = CreateCheckbox(
+        sc, "Show cooldown numbers",
+        "Display the remaining time on active cooldowns. Requires cooldown swipes.",
+        cooldownDesc, "showCooldownText"
+    )
+
     local keybindCheck, keybindDesc = CreateCheckbox(
         sc, "Show keybindings",
         "Display the keybinding text on each icon.",
-        cooldownDesc, "showKeybinds"
+        cooldownTextDesc, "showKeybinds"
     )
 
     local rangeCheck, rangeDesc = CreateCheckbox(
@@ -520,6 +526,7 @@ local function CreateFeaturesPanel()
         RunAfterLayout(panel, sc, function()
             castCheck.sync()
             cooldownCheck.sync()
+            cooldownTextCheck.sync()
             keybindCheck.sync()
             rangeCheck.sync()
             whyCheck.sync()

--- a/tests/test_cooldown_text_option.lua
+++ b/tests/test_cooldown_text_option.lua
@@ -1,0 +1,81 @@
+local function read_file(path)
+    local f = assert(io.open(path, "r"))
+    local text = f:read("*a")
+    f:close()
+    return text
+end
+
+local function assert_contains(text, needle, msg)
+    if not text:find(needle, 1, true) then
+        error(msg or ("missing expected text: " .. needle), 2)
+    end
+end
+
+local function assert_not_contains(text, needle, msg)
+    if text:find(needle, 1, true) then
+        error(msg or ("unexpected text: " .. needle), 2)
+    end
+end
+
+local passed, failed = 0, 0
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+    else
+        failed = failed + 1
+        print("FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+test("cooldown remaining text is opt-in by default", function()
+    local core = read_file("Core.lua")
+    assert_contains(core, "showCooldownText = false",
+        "Core defaults should expose an opt-in showCooldownText setting")
+end)
+
+test("settings panel exposes a cooldown text checkbox", function()
+    local settings = read_file("SettingsPanel.lua")
+    assert_contains(settings, "showCooldownText",
+        "SettingsPanel should wire the showCooldownText option")
+    assert_contains(settings, "Show cooldown numbers",
+        "SettingsPanel should present a user-facing cooldown numbers label")
+    assert_contains(settings, "cooldownTextCheck.sync()",
+        "SettingsPanel should keep the cooldown text checkbox synced on show")
+end)
+
+test("display creates and clears a per-icon cooldown text overlay", function()
+    local display = read_file("Display.lua")
+    assert_contains(display, "cooldownText",
+        "Display should create a per-icon cooldownText font string")
+    assert_contains(display, "ClearCooldownText",
+        "Display should have a central helper for hiding cooldown text")
+    assert_contains(display, "UpdateCooldownText",
+        "Display should update cooldown text separately from swipe rendering")
+end)
+
+test("cooldown text hides when its option or swipe rendering is disabled", function()
+    local display = read_file("Display.lua")
+    assert_contains(display, "showCooldownText",
+        "Display should read the showCooldownText option")
+    assert_contains(display, "showCooldownSwipe",
+        "Display should keep tying text visibility to active cooldown visuals")
+    assert_contains(display, "ClearCooldownText(icon)",
+        "Display should hide cooldown text on ready/disabled paths")
+    assert_contains(display, "self:UpdateCooldownText(icon, spellID)",
+        "Display should refresh cooldown text during queue rendering")
+end)
+
+test("cooldown text avoids unknown or secret cooldown values", function()
+    local display = read_file("Display.lua")
+    assert_contains(display, "issecretvalue",
+        "Display cooldown text should preserve secret-value guards")
+    assert_not_contains(display, "cooldownText:SetText(current)",
+        "Cooldown text must not display raw secret passthrough values")
+end)
+
+if failed > 0 then
+    error(string.format("%d passed, %d failed", passed, failed))
+end
+
+print(string.format("%d passed, %d failed", passed, failed))


### PR DESCRIPTION
## Summary
- adds an opt-in setting for cooldown numbers on queue icons
- renders compact remaining-time text only when cooldown swipes are enabled and readable cooldown data is active
- hides the text for ready spells, short cooldowns, disabled swipes, and unreadable cooldown values
- adds regression coverage for the option, settings wiring, and display update surface

## Tests
- `scripts/run_tests.sh`
- `git diff --cached --check`
- `luac -p Core.lua Display.lua SettingsPanel.lua tests/test_cooldown_text_option.lua`

Notes: follows up on the cooldown-number suggestion from #94 without changing the default overlay behavior.
